### PR TITLE
aop활용한 APIResposne응답 및 예외 처리

### DIFF
--- a/src/main/java/com/cMall/feedShop/common/aop/ApiResponseFormat.java
+++ b/src/main/java/com/cMall/feedShop/common/aop/ApiResponseFormat.java
@@ -1,0 +1,12 @@
+package com.cMall.feedShop.common.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiResponseFormat {
+    String message() default "";
+}

--- a/src/main/java/com/cMall/feedShop/common/aop/ResponseFormatAspect.java
+++ b/src/main/java/com/cMall/feedShop/common/aop/ResponseFormatAspect.java
@@ -1,0 +1,36 @@
+package com.cMall.feedShop.common.aop;
+
+import com.cMall.feedShop.common.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class ResponseFormatAspect {
+
+    @Around("@annotation(apiResponseFormat)")
+    public Object formatResponse(ProceedingJoinPoint joinPoint, ApiResponseFormat apiResponseFormat) throws Throwable {
+        try {
+            Object result = joinPoint.proceed();
+
+            // 이미 ApiResponse 타입이면 그대로 반환
+            if (result instanceof ApiResponse) {
+                return result;
+            }
+
+            // 성공 응답으로 래핑
+            String message = apiResponseFormat.message().isEmpty() ?
+                    "요청이 성공했습니다." : apiResponseFormat.message();
+
+            return ApiResponse.success(message, result);
+
+        } catch (Exception e) {
+            log.error("API 실행 중 오류 발생: {}", e.getMessage(), e);
+            throw e; // 예외는 GlobalExceptionHandler에서 처리
+        }
+    }
+}

--- a/src/main/java/com/cMall/feedShop/common/dto/ApiResponse.java
+++ b/src/main/java/com/cMall/feedShop/common/dto/ApiResponse.java
@@ -1,0 +1,29 @@
+package com.cMall.feedShop.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiResponse<T> {
+    private boolean success;
+    private String message;
+    private T data;
+    private String timestamp;
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, "요청이 성공했습니다.", data, LocalDateTime.now().toString());
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data, LocalDateTime.now().toString());
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(false, message, null, LocalDateTime.now().toString());
+    }
+}

--- a/src/main/java/com/cMall/feedShop/common/exception/BusinessException.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/BusinessException.java
@@ -1,0 +1,18 @@
+package com.cMall.feedShop.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
@@ -1,0 +1,33 @@
+package com.cMall.feedShop.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    // 공통
+    INVALID_INPUT_VALUE(400, "C001", "잘못된 입력값입니다."),
+    METHOD_NOT_ALLOWED(405, "C002", "지원하지 않는 HTTP 메서드입니다."),
+    INTERNAL_SERVER_ERROR(500, "C003", "서버 오류가 발생했습니다."),
+
+    // 인증/인가
+    UNAUTHORIZED(401, "A001", "인증이 필요합니다."),
+    FORBIDDEN(403, "A002", "권한이 없습니다."),
+
+    // 사용자
+    USER_NOT_FOUND(404, "U001", "사용자를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(409, "U002", "이미 존재하는 이메일입니다."),
+
+    // 상품
+    PRODUCT_NOT_FOUND(404, "P001", "상품을 찾을 수 없습니다."),
+    OUT_OF_STOCK(409, "P002", "재고가 부족합니다."),
+
+    // 주문
+    ORDER_NOT_FOUND(404, "O001", "주문을 찾을 수 없습니다."),
+    INVALID_ORDER_STATUS(400, "O002", "잘못된 주문 상태입니다.");
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/cMall/feedShop/common/exception/ErrorResponse.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/ErrorResponse.java
@@ -1,0 +1,63 @@
+package com.cMall.feedShop.common.exception;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class ErrorResponse {
+    private final boolean success = false;
+    private final String code;
+    private final String message;
+    private final String timestamp;
+    private final List<FieldError> fieldErrors;
+
+    // 생성자
+    private ErrorResponse(String code, String message, String timestamp, List<FieldError> fieldErrors) {
+        this.code = code;
+        this.message = message;
+        this.timestamp = timestamp;
+        this.fieldErrors = fieldErrors;
+    }
+
+    // 팩토리 메서드 (필드 에러 없음)
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                LocalDateTime.now().toString(),
+                new ArrayList<>()
+        );
+    }
+
+    // 팩토리 메서드 (필드 에러 포함)
+    public static ErrorResponse of(ErrorCode errorCode, List<FieldError> fieldErrors) {
+        return new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                LocalDateTime.now().toString(),
+                fieldErrors
+        );
+    }
+
+    // 내부 클래스
+    @Getter
+    public static class FieldError {
+        private final String field;
+        private final String value;
+        private final String reason;
+
+        private FieldError(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+
+        // 팩토리 메서드
+        public static FieldError of(String field, String value, String reason) {
+            return new FieldError(field, value, reason);
+        }
+    }
+}

--- a/src/main/java/com/cMall/feedShop/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,61 @@
+package com.cMall.feedShop.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    // 비즈니스 예외
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        log.error("BusinessException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(e.getErrorCode());
+        return ResponseEntity.status(e.getErrorCode().getStatus()).body(response);
+    }
+
+    // 유효성 검사 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("Validation error: {}", e.getMessage());
+
+        List<ErrorResponse.FieldError> fieldErrors = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> ErrorResponse.FieldError.of(
+                        error.getField(),
+                        error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                        error.getDefaultMessage()
+                ))
+                .collect(Collectors.toList());
+
+
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, fieldErrors);
+        return ResponseEntity.badRequest().body(response);
+    }
+
+    // 일반 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Unexpected error: {}", e.getMessage(), e);
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    // 권한 예외
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("Access denied: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.FORBIDDEN);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+}

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 
 @Getter
 public class UserSignUpRequest {
-    private String username; // ERD의 login_id에 해당
-    @CustomEncryption // 비밀번호 암호화를 위한 어노테이션
+    private String loginId;
+    @CustomEncryption
     private String password;
     private String email;
     private String phone;

--- a/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
@@ -25,7 +25,7 @@ public class UserService {
 
     public UserResponse signUp(UserSignUpRequest request) {
         // 1. 중복 체크
-        if (userRepository.existsByUsername(request.getUsername())) {
+        if (userRepository.existsByLoginId(request.getLoginId())) {
             throw new RuntimeException("이미 존재하는 사용자입니다.");
         }
 
@@ -33,7 +33,7 @@ public class UserService {
 
         // 3. 사용자 생성 및 저장
         User user = new User(
-                request.getUsername(),
+                request.getLoginId(),
                 encodedPasswordFromRequest, // 이미 암호화된 비밀번호 사용
                 request.getEmail(),
                 request.getPhone(),

--- a/src/main/java/com/cMall/feedShop/user/domain/model/User.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/User.java
@@ -27,7 +27,7 @@ public class User implements UserDetails {
     private Long id;
 
     @Column(name = "login_id", unique = true, nullable = false, length = 100)
-    private String username;
+    private String loginId;
 
     @Column(nullable = false, length = 255)
     private String password;
@@ -56,8 +56,8 @@ public class User implements UserDetails {
     private String phone;
 
     //(회원가입 시 사용)
-    public User(String username, String password, String email, String phone, UserRole role) {
-        this.username = username;
+    public User(String loginId, String password, String email, String phone, UserRole role) {
+        this.loginId = loginId;
         this.password = password;
         this.email = email;
         this.phone = phone;
@@ -71,6 +71,11 @@ public class User implements UserDetails {
     // 비즈니스 메서드
     public void changePassword(String newPassword) {
         // 도메인 규칙 검증
+    }
+
+    @Override
+    public String getUsername() {
+        return loginId;
     }
 
     public boolean canLogin() {

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
@@ -7,8 +7,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByUsername(String username);
+    boolean existsByLoginId(String loginId);
 
-    // 사용자 이름으로 User 엔티티를 찾는 메서드 (UserService에서 사용)
-    Optional<User> findByUsername(String username);
+    Optional<User> findByLoginId(String loginId);
 }


### PR DESCRIPTION
 @ApiResponseFormat 어노테이션 -> 메서드 레벨에 적용
이미 ApiResponse 타입이면 그대로 반환.
그렇지 않으면 ApiResponse.success(message, result)로 래핑하여 반환.
예외가 발생하면 GlobalExceptionHandler로 처리를 위임

예외 처리 방식
ResponseFormatAspect의 @Around 어드바이스 내에서 try-catch 블록이 사용
try 블록에서 메서드를 실행(joinPoint.proceed())하고, 정상적으로 반환된 결과는 ApiResponse로 래핑
catch 블록에서는 예외를 로깅(log.error)한 뒤, 예외를 다시 던짐(throw e)
이 AOP는 예외를 직접 처리(예: 커스텀 응답 생성)하지 않고, 예외를 GlobalExceptionHandler로 넘김
실제 예외 처리는 GlobalExceptionHandler에서 이루어집니다.


예시
@RestController
public class SampleController {

    @GetMapping("/sample")
    @ApiResponseFormat(message = "샘플 데이터 조회 성공")
    public List<String> getSampleData() {
        return Arrays.asList("item1", "item2");
    }
}

getSampleData 메서드에 @ApiResponseFormat이 붙어 있으므로, AOP가 개입.
반환 값 List<String>은 ApiResponse.success("샘플 데이터 조회 성공", ["item1", "item2"])로 래핑됨.
클라이언트는 다음과 같은 JSON 응답을 받음 (예시):
json


{
  "status": "success",
  "message": "샘플 데이터 조회 성공",
  "data": ["item1", "item2"]
}


요약:
클래스 전체가 아니라 개별 메서드에 @ApiResponseFormat을 붙여야 동작.
AOP는 해당 메서드의 반환 값을 자동으로 ApiResponse 형식으로 포맷팅.
메시지는 어노테이션의 message 속성으로 커스터마이징 가능, 기본은 "요청이 성공했습니다

