### PR TITLE
GlobalExceptionHandler 예외 처리 ApiResponse형태로 수정

### DIFF
--- a/src/main/java/com/cMall/feedShop/common/aop/ResponseFormatAspect.java
+++ b/src/main/java/com/cMall/feedShop/common/aop/ResponseFormatAspect.java
@@ -29,7 +29,8 @@ public class ResponseFormatAspect {
             return ApiResponse.success(message, result);
 
         } catch (Exception e) {
-            log.error("API 실행 중 오류 발생: {}", e.getMessage(), e);
+            log.error("API 실행 중 오류 발생 - Method: {}, Error: {}",
+                    joinPoint.getSignature().getName(), e.getMessage());
             throw e; // 예외는 GlobalExceptionHandler에서 처리
         }
     }

--- a/src/main/java/com/cMall/feedShop/common/dto/ApiResponse.java
+++ b/src/main/java/com/cMall/feedShop/common/dto/ApiResponse.java
@@ -1,29 +1,44 @@
 package com.cMall.feedShop.common.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
 public class ApiResponse<T> {
     private boolean success;
     private String message;
     private T data;
-    private String timestamp;
+    @Builder.Default
+    private String timestamp = LocalDateTime.now().toString();
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, "요청이 성공했습니다.", data, LocalDateTime.now().toString());
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message("요청이 성공했습니다.")
+                .data(data)
+                .build();
     }
 
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(true, message, data, LocalDateTime.now().toString());
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .build();
     }
 
     public static <T> ApiResponse<T> error(String message) {
-        return new ApiResponse<>(false, message, null, LocalDateTime.now().toString());
+        return ApiResponse.<T>builder()
+                .success(false)
+                .message(message)
+                .data(null)
+                .build();
     }
 }


### PR DESCRIPTION
1. 응답 형태 일관성 확보

GlobalExceptionHandler의 모든 예외 처리에서 ApiResponse 형태로 반환하도록 수정
AOP의 성공 응답과 동일한 구조 유지 (success, message, data, timestamp)

2. ApiResponse에 Builder 패턴 추가

더 유연한 객체 생성을 위해 @Builder 추가
예외 처리에서 더 명확하게 응답 객체 생성 가능

3. 예외별 세분화된 처리

AuthenticationException 추가로 인증 관련 예외 별도 처리
각 예외별로 적절한 HTTP 상태 코드와 메시지 반환

4. AOP와의 완벽한 연동

AOP에서 발생한 예외는 GlobalExceptionHandler에서 처리
성공/실패 모두 동일한 ApiResponse 구조 사용