### PR TITLE
Feat - SonarCloud 통합 및 Jacoco 코드 커버리지 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.3.12'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id 'org.sonarqube' version '5.1.0.4882'
+	id 'jacoco'
 }
 
 group = 'com.cMall'
@@ -45,4 +47,39 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy jacocoTestReport
+}
+
+jacoco {
+	toolVersion = "0.8.11" // 최신 Jacoco 버전 확인 후 적용
+}
+
+jacocoTestReport {
+	dependsOn test // jacocoTestReport 태스크가 test 태스크 실행 이후에 실행되도록 의존성 설정
+	reports {
+		xml.required = true // SonarCloud가 읽을 수 있도록 XML 리포트 필수
+		csv.required = false
+		html.required = true // 사람이 읽기 쉬운 HTML 리포트도 생성 (선택 사항)
+	}
+	// 보고서가 생성될 경로 설정 (SonarCloud에서 이 경로를 참조하게 됨)
+	// destinationFile = file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml") // 기본 경로와 동일하면 명시하지 않아도 됨
+	// html.outputLocation = file("${buildDir}/reports/jacoco/html") // HTML 리포트 출력 경로 (선택 사항)
+}
+
+// SonarCloud 설정 추가
+sonarqube {
+	properties {
+		property "sonar.projectKey", "ECommerceCommunity_FeedShop_Backend"
+		property "sonar.organization", "ecommercecommunity"
+
+		// 코드 커버리지를 Jacoco 리포트와 연동
+		property "sonar.java.coveragePlugin", "jacoco"
+		// Jacoco XML 리포트 파일의 경로를 SonarCloud에 알려줍니다.
+		// Jacoco 설정을 통해 생성되는 기본 경로와 일치하는지 확인하세요.
+		property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+
+		// 분석에서 제외할 파일이나 디렉토리를 지정할 수 있습니다. (선택 사항)
+		// property "sonar.exclusions", "**/generated/**, **/*.html"
+		// property "sonar.test.exclusions", "**/*Test.java" // 테스트 파일 제외 예시
+	}
 }


### PR DESCRIPTION
작업 내용
build.gradle에 SonarCloud 분석을 위한 플러그인과 설정을 추가했습니다.

Jacoco 플러그인을 추가하여 테스트 코드 커버리지 보고서를 생성하도록 설정했습니다.

SonarCloud가 Jacoco에서 생성된 XML 보고서를 사용하여 코드 커버리지를 분석하도록 연동했습니다.

변경 사항 상세
plugins 블록에 org.sonarqube 및 jacoco 플러그인 추가.

jacoco 태스크에 toolVersion 설정 및 jacocoTestReport 태스크 구성:

dependsOn test를 통해 테스트 실행 후 Jacoco 보고서가 생성되도록 설정.

XML 및 HTML 보고서 생성을 활성화.

sonarqube 블록에 SonarCloud 프로젝트 및 조직 키 설정 (sonar.projectKey, sonar.organization).

sonar.java.coveragePlugin을 jacoco로 설정하여 Jacoco와 연동.

sonar.coverage.jacoco.xmlReportPaths에 Jacoco XML 보고서 경로를 명시하여 SonarCloud가 커버리지 데이터를 가져올 수 있도록 설정.

목적
코드 품질 및 코드 커버리지 자동 분석 환경을 구축하여 개발 프로세스 개선.

지속적인 코드 품질 관리를 통해 잠재적인 버그를 조기에 발견하고 코드 안정성 향상.

팀 내 코드 품질 기준을 확립하고 유지하는 데 기여.