### PR TITLE
MYCE-15 feat: 회원가입 및 이메일 인증 기능 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,65 +11,65 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout Repository 
-      uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v4
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-        cache: 'gradle'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
 
-    - name: Clean build directory
-      run: ./gradlew clean
+      - name: Clean build directory
+        run: ./gradlew clean
 
-    - name: Run Tests
-      run: ./gradlew test --continue
-      env:
-        SPRING_PROFILES_ACTIVE: test
+      - name: Run Tests
+        run: ./gradlew test --continue
+        env:
+          SPRING_PROFILES_ACTIVE: test
 
 
-    - name: Generate Test Coverage Report
-      run: ./gradlew jacocoTestReport
+      - name: Generate Test Coverage Report
+        run: ./gradlew jacocoTestReport
 
-    - name: Build Project (without tests) # 테스트를 제외하고 프로젝트를 빌드합니다.
-      # 이 단계에서는 application.properties가 기본으로 사용되며,
-      # 만약 해당 파일에 환경 변수(DB_HOST, SERVER_PORT 등)가 정의되어 있고,
-      # 빌드 시에 해당 변수들이 필요하다면 아래 'env' 섹션을 추가해야 합니다.
-      # 일반적으로 JAR/WAR 파일 생성 시에는 플레이스홀더를 포함한 채로 빌드하고,
-      # 실제 실행 환경에서 환경 변수를 주입하는 것이 일반적입니다.
-      # 하지만 만약 빌드 자체가 특정 환경 변수를 필요로 한다면:
-      # env:
-      #   DB_HOST: ${{ secrets.DB_HOST_PROD }} # 예시: 실제 운영 DB 호스트
-      #   DB_PORT: ${{ secrets.DB_PORT_PROD }}
-      #   SPRING_PROFILES_ACTIVE: production # 만약 빌드 시에 'production' 프로파일을 사용하고 싶다면
-      run: ./gradlew build -x test
+      - name: Build Project (without tests) # 테스트를 제외하고 프로젝트를 빌드합니다.
+        # 이 단계에서는 application.properties가 기본으로 사용되며,
+        # 만약 해당 파일에 환경 변수(DB_HOST, SERVER_PORT 등)가 정의되어 있고,
+        # 빌드 시에 해당 변수들이 필요하다면 아래 'env' 섹션을 추가해야 합니다.
+        # 일반적으로 JAR/WAR 파일 생성 시에는 플레이스홀더를 포함한 채로 빌드하고,
+        # 실제 실행 환경에서 환경 변수를 주입하는 것이 일반적입니다.
+        # 하지만 만약 빌드 자체가 특정 환경 변수를 필요로 한다면:
+        # env:
+        #   DB_HOST: ${{ secrets.DB_HOST_PROD }} # 예시: 실제 운영 DB 호스트
+        #   DB_PORT: ${{ secrets.DB_PORT_PROD }}
+        #   SPRING_PROFILES_ACTIVE: production # 만약 빌드 시에 'production' 프로파일을 사용하고 싶다면
+        run: ./gradlew build -x test
 
-    - name: Upload Test Results
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results
-        path: build/test-results/test/*.xml
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/test-results/test/*.xml
 
-    - name: Upload Test Coverage # 테스트 커버리지 보고서 아티팩트를 업로드합니다.
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-coverage
-        path: build/reports/jacoco/test/jacocoTestReport.xml
+      - name: Upload Test Coverage # 테스트 커버리지 보고서 아티팩트를 업로드합니다.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-coverage
+          path: build/reports/jacoco/test/jacocoTestReport.xml
 
-    - name: Analyze with SonarQube
-      run: | 
-        ./gradlew sonarqube \
-        -Dsonar.projectKey=ECommerceCommunity_FeedShop_Backend \
-        -Dsonar.projectName="FeedShop_Backend" \
-        -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
-        -Dsonar.organization=ecommercecommunity #
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      - name: Analyze with SonarQube
+        run: |
+          ./gradlew sonarqube \
+          -Dsonar.projectKey=ECommerceCommunity_FeedShop_Backend \
+          -Dsonar.projectName="FeedShop_Backend" \
+          -Dsonar.token=${{ secrets.SONAR_TOKEN }} \
+          -Dsonar.organization=ecommercecommunity #
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,0 +1,24 @@
+name: Create Jira issue # 1
+on: # 2
+  issues: 
+    types: [opened] 
+    
+jobs: # 3
+  create-issue:  # 4
+    name: Create Jira issue # 5
+    runs-on: ubuntu-latest # 6
+    steps: # 7
+    - name: Login
+      uses: atlassian/gajira-login@v3 # 8
+      env: 
+        JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }} # 9
+        JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+        JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+    
+    - name: Create Issue 
+      uses: atlassian/gajira-create@v3
+      with:
+        project: ${{ secrets.JIRA_PROJECT_KEY }}  # 10 - 프로젝트 key
+        issuetype: Task # 11 - 이슈 타입
+        summary: '${{ github.event.issue.title }}'
+        description: '${{ github.event.issue.html_url }}'

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	// JWT 라이브러리 추가
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatch.java
+++ b/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatch.java
@@ -1,0 +1,18 @@
+package com.cMall.feedShop.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE}) // 클래스, 인터페이스, Enum에 적용 가능
+@Retention(RetentionPolicy.RUNTIME) // 런타임 시까지 유지
+@Constraint(validatedBy = CustomPasswordMatchValidator.class)
+public @interface CustomPasswordMatch {
+    String message() default "비밀번호와 비밀번호 확인이 일치하지 않습니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatchValidator.java
+++ b/src/main/java/com/cMall/feedShop/annotation/CustomPasswordMatchValidator.java
@@ -1,0 +1,34 @@
+package com.cMall.feedShop.annotation;
+
+
+import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CustomPasswordMatchValidator implements ConstraintValidator<CustomPasswordMatch, UserSignUpRequest> {
+
+    @Override
+    public boolean isValid(UserSignUpRequest request, ConstraintValidatorContext context) {
+        if (request == null) {
+            return true; // null 객체는 이 검증의 대상이 아니라고 판단할 수 있음
+        }
+
+        // 비밀번호 또는 비밀번호 확인 필드가 null인 경우 (NotBlank 등 다른 검증이 선행되어야 함)
+        if (request.getPassword() == null || request.getConfirmPassword() == null) {
+            return false; // 둘 중 하나라도 null이면 일치하지 않는 것으로 간주
+        }
+
+        // 실제 비밀번호 일치 여부 검사
+        boolean isValid = request.getPassword().equals(request.getConfirmPassword());
+
+        // 검증 실패 시 기본 메시지 대신 커스텀 메시지를 추가하고 싶다면
+        if (!isValid) {
+            context.disableDefaultConstraintViolation(); // 기본 메시지 비활성화
+            context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())
+                    .addPropertyNode("confirmPassword") // 어떤 필드에 에러를 추가할지 지정
+                    .addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/common/BaseTimeEntity.java
+++ b/src/main/java/com/cMall/feedShop/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.cMall.feedShop.common;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter // Lombok: 모든 필드에 대한 getter 메서드를 자동으로 생성해줍니다.
+@MappedSuperclass // JPA: 이 클래스가 엔티티들의 상위 클래스임을 나타냅니다. 이 클래스의 필드들은 자식 엔티티의 테이블 컬럼으로 매핑됩니다. (테이블로 생성되지는 않음)
+@EntityListeners(AuditingEntityListener.class) // JPA: 엔티티의 영속성 이벤트(생성, 수정 등)를 감지하는 리스너를 지정합니다. 여기서는 Spring Data JPA의 Auditing 기능을 활성화합니다.
+public class BaseTimeEntity {
+    @CreatedDate // Spring Data JPA Auditing: 엔티티가 생성될 때 현재 시간을 자동으로 주입합니다.
+    @Column(name = "created_at", nullable = false, updatable = false) // JPA: 데이터베이스 컬럼명, null 허용 안 함, 업데이트 불가능
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate // Spring Data JPA Auditing: 엔티티가 수정될 때마다 현재 시간을 자동으로 주입합니다.
+    @Column(name = "updated_at", nullable = false) // JPA: 데이터베이스 컬럼명, null 허용 안 함
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/cMall/feedShop/common/service/EmailService.java
+++ b/src/main/java/com/cMall/feedShop/common/service/EmailService.java
@@ -1,0 +1,55 @@
+package com.cMall.feedShop.common.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EmailService {
+    private final JavaMailSender emailSender;
+
+    // 간단한 텍스트 이메일 전송 메서드
+    public void sendSimpleEmail(String toEmail, String subject, String text) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setFrom("jsm1592@gmail.com");
+        message.setTo(toEmail);
+        message.setSubject(subject);
+        message.setText(text);
+
+        try {
+            emailSender.send(message);
+            log.info("이메일 전송 성공: To={}, Subject={}", toEmail, subject);
+        } catch (MailException e) {
+            log.error("이메일 전송 실패: To={}, Subject={}, Error={}", toEmail, subject, e.getMessage(), e);
+            throw new RuntimeException("이메일 전송에 실패했습니다.", e);
+        }
+    }
+
+    // HTML 형식의 이메일 전송 메서드 (필요하다면 사용)
+    public void sendHtmlEmail(String toEmail, String subject, String htmlContent) {
+        try {
+            MimeMessage message = emailSender.createMimeMessage();
+            // true는 멀티파트 메시지(파일 첨부 등)를 허용하고, "UTF-8"은 인코딩을 지정합니다.
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom("jsm1592@gmail.com"); // 발신자 이메일
+            helper.setTo(toEmail); // 수신자 이메일
+            helper.setSubject(subject); // 이메일 제목
+            helper.setText(htmlContent, true); // true를 넣어 HTML임을 명시
+
+            emailSender.send(message);
+            log.info("HTML 이메일 전송 성공: To={}, Subject={}", toEmail, subject);
+        } catch (MessagingException e) {
+            log.error("HTML 이메일 전송 실패: To={}, Subject={}, Error={}", toEmail, subject, e.getMessage(), e);
+            throw new RuntimeException("HTML 이메일 전송에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/cMall/feedShop/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/PasswordEncoderConfig.java
@@ -1,0 +1,33 @@
+package com.cMall.feedShop.config;
+
+import com.cMall.feedShop.user.infrastructure.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+
+@Configuration
+@RequiredArgsConstructor
+public class PasswordEncoderConfig {
+
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(
+            PasswordEncoder passwordEncoder) {
+        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
+        authenticationProvider.setUserDetailsService(customUserDetailsService);
+        authenticationProvider.setPasswordEncoder(passwordEncoder);
+        return new ProviderManager(authenticationProvider);
+    }
+}

--- a/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/SecurityConfig.java
@@ -24,26 +24,6 @@ import java.util.List;
 @EnableWebSecurity
 public class SecurityConfig {
 
-    private final CustomUserDetailsService customUserDetailsService;
-
-    public SecurityConfig(CustomUserDetailsService customUserDetailsService) {
-        this.customUserDetailsService = customUserDetailsService;
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
-    public AuthenticationManager authenticationManager(
-            PasswordEncoder passwordEncoder) {
-        DaoAuthenticationProvider authenticationProvider = new DaoAuthenticationProvider();
-        authenticationProvider.setUserDetailsService(customUserDetailsService);
-        authenticationProvider.setPasswordEncoder(passwordEncoder);
-        return new ProviderManager(authenticationProvider);
-    }
-
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity
@@ -60,8 +40,8 @@ public class SecurityConfig {
                 )
 
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/public/**",
-                                "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/signup", "/api/auth/verify-email",
+                                "/public/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 // 폼 로그인 및 HTTP Basic 인증은 사용하지 않음

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
@@ -1,13 +1,43 @@
 package com.cMall.feedShop.user.application.dto.request;
 
 import com.cMall.feedShop.annotation.CustomEncryption;
+import com.cMall.feedShop.annotation.CustomPasswordMatch;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
+@CustomPasswordMatch
 public class UserSignUpRequest {
-    private String loginId;
-    @CustomEncryption
-    private String password;
+    @NotBlank(message = "이름은 필수 입력 값입니다.")
+    @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
+    private String name;
+
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
+    @Email(message = "유효한 이메일 주소를 입력해주세요.")
+    @Size(max = 255, message = "이메일은 255자 이하로 입력해주세요.")
     private String email;
+
+    private String loginId;
+
+    @CustomEncryption
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 255, message = "비밀번호는 8자 이상으로 입력해주세요.")
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?])(?=.*[0-9]).*$",
+            message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")
+    private String confirmPassword; // 비밀번호 확인 필드
+
+    @NotBlank(message = "휴대폰 번호는 필수입니다.")
     private String phone;
+
+    private UserRole role = UserRole.USER;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/response/UserResponse.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/response/UserResponse.java
@@ -17,6 +17,7 @@ public class UserResponse {
     private UserRole role; 
     private String status; 
     private LocalDateTime createdAt;
+    private String message;
 
     // User 엔티티를 UserResponse DTO로 변환하는 정적 팩토리 메서드
     public static UserResponse from(User user) {
@@ -24,10 +25,21 @@ public class UserResponse {
                 .userId(user.getId())
                 .username(user.getUsername())
                 .email(user.getEmail())
-                .phone(user.getPhone())
                 .role(user.getRole())
                 .status(user.getStatus().name()) // Enum을 String으로 변환하여 반환
                 .createdAt(user.getCreatedAt())
+                .build();
+    }
+
+    public static UserResponse from(User user, String message) {
+        return UserResponse.builder()
+                .userId(user.getId())
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .status(user.getStatus().name()) // Enum을 String으로 변환하여 반환
+                .createdAt(user.getCreatedAt())
+                .message(message)
                 .build();
     }
 }

--- a/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserService.java
@@ -1,78 +1,181 @@
 package com.cMall.feedShop.user.application.service;
 
-//import com.cMall.feedShop.user.application.dto.request.UserLoginRequest;
+import com.cMall.feedShop.common.service.EmailService;
 import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
-//import com.cMall.feedShop.user.application.dto.response.AuthTokenResponse;
 import com.cMall.feedShop.user.application.dto.response.UserResponse;
 import com.cMall.feedShop.user.domain.model.User;
 import com.cMall.feedShop.user.domain.enums.UserRole;
 import com.cMall.feedShop.user.domain.enums.UserStatus;
+import com.cMall.feedShop.user.domain.model.UserProfile;
+import com.cMall.feedShop.user.domain.repository.UserProfileRepository;
 import com.cMall.feedShop.user.domain.repository.UserRepository;
-import lombok.RequiredArgsConstructor; // Lombok 임포트
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// JWT 토큰 발급/검증을 위한 JwtProvider는 일단 주석 처리 (JWT 도입 전까지)
-// import com.cMall.feedShop.user.application.jwt.JwtProvider; // 가상의 JwtProvider
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @Transactional
-@RequiredArgsConstructor // final 필드를 인자로 받는 생성자를 자동 생성
+@RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
-    // private final JwtProvider jwtProvider;
+    private final UserProfileRepository userProfileRepository;
     private final PasswordEncoder passwordEncoder;
+    private final EmailService emailService;
 
     public UserResponse signUp(UserSignUpRequest request) {
-        // 1. 중복 체크
-        if (userRepository.existsByLoginId(request.getLoginId())) {
-            throw new RuntimeException("이미 존재하는 사용자입니다.");
+
+        // 이메일 중복 확인 및 상태에 따른 처리
+        Optional<User> existingUserOptional = userRepository.findByEmail(request.getEmail());
+
+        if (existingUserOptional.isPresent()) {
+            User existingUser = existingUserOptional.get();
+
+            if (existingUser.getStatus() == UserStatus.ACTIVE) {
+                // 이미 활성(ACTIVE) 상태의 사용자가 해당 이메일로 가입되어 있다면
+                throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            } else if (existingUser.getStatus() == UserStatus.PENDING) {
+                // PENDING 상태의 사용자가 존재한다면 (이메일 인증 미완료)
+                // 기존 PENDING 계정의 인증 토큰 및 만료 시간 업데이트
+                String newVerificationToken = UUID.randomUUID().toString();
+                LocalDateTime newExpiryTime = LocalDateTime.now().plusHours(1);
+
+                existingUser.setVerificationToken(newVerificationToken);
+                existingUser.setVerificationTokenExpiry(newExpiryTime);
+                userRepository.save(existingUser); // 업데이트된 사용자 정보 저장
+
+                // 사용자에게 재인증 메일 전송
+                String verificationLink = "https://localhost:8443/api/auth/verify-email?token=" + newVerificationToken;
+                String emailSubject = "[cMall] 회원가입 재인증을 완료해주세요.";
+                String emailContent = "안녕하세요, " + existingUser.getUserProfile().getName() + "님!\n\n" +
+                        "회원가입 재인증을 요청하셨습니다. 아래 링크를 클릭하여 이메일 인증을 완료해주세요:\n\n" +
+                        verificationLink + "\n\n" +
+                        "본 링크는 1시간 후 만료됩니다.\n" +
+                        "감사합니다.\ncMall 팀 드림";
+
+                emailService.sendSimpleEmail(existingUser.getEmail(), emailSubject, emailContent);
+
+                return UserResponse.from(
+                        existingUser,
+                        "재인증 메일이 발송되었습니다. 메일을 확인하여 인증을 완료해주세요."
+                );
+            }
+            // 기타 다른 상태 (DELETED 등)에 대한 처리도 추가할 수 있습니다.
         }
 
-        String encodedPasswordFromRequest = request.getPassword();
+        // loginId 자동 생성 및 중복 확인
+        // UI에서 loginId를 받지 않으므로 UUID로 자동 생성
+        String generatedLoginId = UUID.randomUUID().toString();
 
-        // 3. 사용자 생성 및 저장
+        // 4. 비밀번호 암호화
+        String finalPasswordToSave;
+        if (request.getPassword().startsWith("$2a$") || request.getPassword().startsWith("$2b$") || request.getPassword().startsWith("$2y$")) {
+            finalPasswordToSave = request.getPassword();
+        } else {
+            finalPasswordToSave = passwordEncoder.encode(request.getPassword());
+        }
+
+        // 5. User 엔티티 생성 및 초기화
         User user = new User(
-                request.getLoginId(),
-                encodedPasswordFromRequest, // 이미 암호화된 비밀번호 사용
+                generatedLoginId,
+                finalPasswordToSave,
                 request.getEmail(),
-                request.getPhone(),
-                UserRole.ROLE_USER
+                UserRole.USER
         );
-        userRepository.save(user);
+        user.setStatus(UserStatus.PENDING);
+        user.setPasswordChangedAt(LocalDateTime.now()); // 초기 비밀번호 변경 시간 설정
 
-        // 4. UserResponse로 변환해서 반환
+        String verificationToken = UUID.randomUUID().toString();
+
+        LocalDateTime tokenExpiryTime = LocalDateTime.now().plusHours(1); // 예: 1시간 후 만료
+
+        user.setVerificationToken(verificationToken);
+        user.setVerificationTokenExpiry(tokenExpiryTime);
+
+        // 6. UserProfile 엔티티 생성
+        UserProfile userProfile = new UserProfile(
+                user,
+                request.getName(),
+                request.getName(),
+                request.getPhone()
+        );
+
+        user.setUserProfile(userProfile);
+
+        userRepository.save(user); // User에 cascade = CascadeType.ALL 설정 시 UserProfile도 함께 저장됨
+
+
+        // 이메일 전송
+        String verificationLink = "https://localhost:8443/api/auth/verify-email?token=" + verificationToken;
+        String emailSubject = "[cMall] 회원가입을 완료해주세요.";
+        String emailContent = "안녕하세요, " + request.getName() + "님!\n\n" +
+                "cMall 회원가입을 환영합니다. 아래 링크를 클릭하여 이메일 인증을 완료해주세요:\n\n" +
+                verificationLink + "\n\n" +
+                "본 링크는 1시간 후 만료됩니다.\n" +
+                "감사합니다.\ncMall 팀 드림";
+
+        emailService.sendSimpleEmail(request.getEmail(), emailSubject, emailContent);
+
+        // 9. 응답 DTO 반환
         return UserResponse.from(user);
     }
 
+    // 아이디 중복 확인 메서드 (API 제공 시 활용)
+    @Transactional(readOnly = true)
+    public boolean isLoginIdDuplicated(String loginId) {
+        return userRepository.existsByLoginId(loginId);
+    }
 
-//    public AuthTokenResponse login(UserLoginRequest request) {
-        // 1. 사용자 검증
-//        User user = userRepository.findByUsername(request.getUsername())
-//                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다."));
+    // 이메일 중복 확인 메서드 (API 제공 시 활용)
+    @Transactional(readOnly = true)
+    public boolean isEmailDuplicated(String email) {
+        return userRepository.existsByEmail(email); // User Repository 사용
+    }
 
-        // 2. 비밀번호 확인
-        // Aspect에서 사용한 PasswordEncryptionService의 matches 메서드를 사용해야 함
-        // 이를 위해 PasswordEncryptionService를 이 UserService에도 주입받아야 합니다.
-        // private final PasswordEncryptionService passwordEncryptionService;
-        // if (!passwordEncryptionService.matches(request.getPassword(), user.getPassword())) {
-        //     throw new RuntimeException("비밀번호가 일치하지 않습니다.");
-        // }
-        // 혹은, 여기에서 Spring Security의 PasswordEncoder를 다시 주입받아 사용할 수도 있습니다.
-        // private final PasswordEncoder passwordEncoder;
-        // if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-        //     throw new RuntimeException("비밀번호가 일치하지 않습니다.");
-        // }
+    /**
+     * 이메일 인증 토큰을 검증하고 사용자 계정을 활성화합니다.
+     * @param token 사용자가 이메일 링크를 통해 전달한 인증 토큰
+     * @throws RuntimeException 토큰이 유효하지 않거나 만료되었을 경우 등
+     */
+    @Transactional
+    public void verifyEmail(String token) {
+        User user = userRepository.findByVerificationToken(token)
+                .orElseThrow(() -> new RuntimeException("유효하지 않거나 찾을 수 없는 인증 토큰입니다."));
 
 
-        // 3. JWT 토큰 생성 (JWT 미도입 시 이 부분은 주석 처리 또는 제거)
-        // String accessToken = jwtProvider.createAccessToken(user.getUsername(), user.getRole().name());
-        // String refreshToken = jwtProvider.createRefreshToken(user.getUsername());
+        // 토큰이 유효한지 (만료되지 않았는지, 이미 사용되었는지) 확인합니다.
 
-        // 4. 토큰 반환 (JWT 미도입 시 적절한 응답으로 변경)
-        // return new AuthTokenResponse(accessToken, refreshToken);
-//        throw new UnsupportedOperationException("JWT is not enabled yet for login."); // 임시
-//    }
+        if (user.getStatus() == UserStatus.ACTIVE) {
+            user.setVerificationToken(null);
+            user.setVerificationTokenExpiry(null);
+            userRepository.save(user);
+            throw new RuntimeException("이미 인증이 완료된 계정입니다.");
+        }
+
+        if (user.getVerificationToken() == null || !user.getVerificationToken().equals(token)) {
+            throw new RuntimeException("인증 토큰이 유효하지 않습니다.");
+        }
+
+        // 토큰이 만료되었는지 확인
+        // verificationTokenExpiry가 null이거나 현재 시간보다 이전이면 만료된 것으로 간주
+        if (user.getVerificationTokenExpiry() == null || user.getVerificationTokenExpiry().isBefore(LocalDateTime.now())) {
+
+            user.setVerificationToken(null);
+            user.setVerificationTokenExpiry(null);
+            userRepository.save(user); // 변경사항 저장
+            throw new RuntimeException("인증 토큰이 만료되었습니다. 다시 회원가입을 시도하거나 인증 메일을 재발송해주세요.");
+        }
+
+        user.setStatus(UserStatus.ACTIVE);
+
+        user.setVerificationToken(null);
+        user.setVerificationTokenExpiry(null);
+
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/enums/UserRole.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/enums/UserRole.java
@@ -1,7 +1,7 @@
 package com.cMall.feedShop.user.domain.enums;
 
 public enum UserRole {
-    ROLE_ADMIN,
-    ROLE_SELLER,
-    ROLE_USER
+    ADMIN,
+    SELLER,
+    USER
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/enums/UserStatus.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/enums/UserStatus.java
@@ -5,5 +5,6 @@ public enum UserStatus {
     ACTIVE,
     INACTIVE,
     BLOCKED,
+    PENDING,
     SUSPENDED
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/model/UserProfile.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/UserProfile.java
@@ -2,10 +2,14 @@ package com.cMall.feedShop.user.domain.model;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "users_profile")
 @Getter
+@Setter
+@NoArgsConstructor
 public class UserProfile {
 
     @Id
@@ -22,4 +26,14 @@ public class UserProfile {
 
     @Column(name="nickname")
     private String nickname;
+
+    @Column(nullable = false, length = 20)
+    private String phone;
+
+    public UserProfile(User user, String name, String nickname, String phone) {
+        this.user = user;
+        this.name = name;
+        this.nickname = nickname;
+        this.phone = phone;
+    }
 }

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
@@ -7,9 +7,13 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByLoginId(String loginId);
-
     Optional<User> findByLoginId(String loginId);
 
+    boolean existsByLoginId(String loginId);
+
     Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email); // email 중복 여부 확인 (signUp 시 사용)
+
+    Optional<User> findByVerificationToken(String verificationToken);
+
 }

--- a/src/main/java/com/cMall/feedShop/user/infrastructure/external/EmailService.java
+++ b/src/main/java/com/cMall/feedShop/user/infrastructure/external/EmailService.java
@@ -1,4 +1,0 @@
-package com.cMall.feedShop.user.infrastructure.external;
-
-public class EmailService {
-}

--- a/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
+++ b/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
@@ -10,34 +10,31 @@ import com.cMall.feedShop.user.application.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor; // Lombok 임포트
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth") // 인증 관련 엔드포인트 기본 경로
-@RequiredArgsConstructor // final 필드를 인자로 받는 생성자를 자동 생성
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class UserAuthController {
 
-    private final UserService userService; // 회원가입 등 기본적인 사용자 CRUD를 담당하는 서비스
-    private final UserAuthService userAuthService; // 로그인 등 인증 관련 로직을 담당하는 서비스
+    private final UserService userService;
+    private final UserAuthService userAuthService;
 
-    // @RequiredArgsConstructor가 생성자를 자동으로 만들어주므로 수동 생성자 삭제
-    // public AuthController(UserService userService, UserAuthService userAuthService) {
-    //     this.userService = userService;
-    //     this.userAuthService = userAuthService;
-    // }
 
     @PostMapping("/signup") // POST /api/auth/signup 요청 처리
     public ResponseEntity<UserResponse> signUp(@Valid @RequestBody UserSignUpRequest request) {
-        // 회원가입은 UserService에 위임 (사용자 생성 로직)
         return ResponseEntity.ok(userService.signUp(request));
     }
 
     @PostMapping("/login") // POST /api/auth/login 요청 처리 (React 코드와 일치)
     public ResponseEntity<UserLoginResponse> login(@Valid @RequestBody UserLoginRequest request) {
-        // 로그인 인증은 AuthService에 위임
         return ResponseEntity.ok(userAuthService.login(request));
+    }
+
+    @GetMapping("/verify-email") // <-- 이 부분이 URL의 /verify-email 경로와 GET 요청을 담당합니다.
+    public ResponseEntity<String> verifyEmail(@RequestParam("token") String token) {
+        // 실제 이메일 인증 로직은 UserService가 수행합니다.
+        userService.verifyEmail(token);
+        return ResponseEntity.ok("이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다.");
     }
 }

--- a/src/main/java/com/cMall/feedShop/user/presentation/UserController.java
+++ b/src/main/java/com/cMall/feedShop/user/presentation/UserController.java
@@ -19,10 +19,4 @@ public class UserController {
         UserProfileResponse response = userProfileService.getUserProfile(userId);
         return response;
     }
-
-    // JWT 로그인 메서드도 있다면 여기에 추가
-    // @PostMapping("/login")
-    // public AuthTokenResponse login(@RequestBody UserLoginRequest request) {
-    //     return userService.login(request);
-    // }
 }

--- a/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
+++ b/src/test/java/com/cMall/feedShop/FeedShopApplicationTests.java
@@ -2,11 +2,17 @@ package com.cMall.feedShop;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
+//@ActiveProfiles("test")
 @SpringBootTest
 class FeedShopApplicationTests {
+  
+    @MockBean
+    private JavaMailSender javaMailSender;
+
     @Test
     void contextLoads() {
     }

--- a/src/test/java/com/cMall/feedShop/user/application/service/UserAuthServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/UserAuthServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder; // PasswordEncoder mock은 AuthenticationManager 내부에서 사용되므로 직접 필요없지만, 생성자에 있다면 Mock으로 주입
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -32,30 +33,29 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ActiveProfiles("test")
-@ExtendWith(MockitoExtension.class) // JUnit 5에서 Mockito를 사용하기 위한 설정
+@ExtendWith(MockitoExtension.class)
 class UserAuthServiceTest {
 
-    @Mock // Mock 객체 생성
+    @Mock
     private UserRepository userRepository;
 
-    @Mock // Mock 객체 생성
-    private PasswordEncoder passwordEncoder; // UserAuthService의 생성자에 있다면 Mock으로 필요
+    @Mock
+    private PasswordEncoder passwordEncoder;
 
-    @Mock // Mock 객체 생성
+    @Mock
     private JwtTokenProvider jwtTokenProvider;
 
-    @Mock // Mock 객체 생성
+    @Mock
     private AuthenticationManager authenticationManager;
 
     @InjectMocks // Mock 객체들을 주입받을 테스트 대상 서비스
     private UserAuthService userAuthService;
 
-    // 테스트에 사용될 공통 데이터
     private UserLoginRequest loginRequest;
     private User testUser;
     private String dummyToken;
 
-    @BeforeEach // 각 테스트 메서드 실행 전에 초기화
+    @BeforeEach
     void setUp() {
         loginRequest = new UserLoginRequest();
         loginRequest.setEmail("test@example.com");
@@ -65,13 +65,13 @@ class UserAuthServiceTest {
                 "testLoginId",
                 "encodedPassword123", // DB에 저장된 암호화된 비밀번호
                 "test@example.com",
-                "010-1234-5678",
-                UserRole.ROLE_USER
+//                "010-1234-5678",
+                UserRole.USER
         );
         // 테스트 객체 생성 시에는 생략하거나 mock 데이터를 직접 설정
         testUser.setId(1L);
-        testUser.setCreatedAt(LocalDateTime.now());
-        testUser.setUpdatedAt(LocalDateTime.now());
+        ReflectionTestUtils.setField(testUser, "createdAt", LocalDateTime.now());
+        ReflectionTestUtils.setField(testUser, "updatedAt", LocalDateTime.now());
         testUser.setPasswordChangedAt(LocalDateTime.now());
 
         dummyToken = "dummy_jwt_token";

--- a/src/test/java/com/cMall/feedShop/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/UserServiceTest.java
@@ -1,0 +1,230 @@
+package com.cMall.feedShop.user.application.service;
+
+import com.cMall.feedShop.common.service.EmailService;
+import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
+import com.cMall.feedShop.user.application.dto.response.UserResponse;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import com.cMall.feedShop.user.domain.enums.UserStatus;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.model.UserProfile;
+import com.cMall.feedShop.user.domain.repository.UserProfileRepository;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private UserProfileRepository userProfileRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    private UserSignUpRequest signUpRequest;
+
+    @Mock
+    private EmailService emailService;
+
+    @BeforeEach
+    void setUp() {
+        signUpRequest = new UserSignUpRequest();
+        signUpRequest.setName("테스트유저");
+        signUpRequest.setEmail("test@example.com");
+        signUpRequest.setPassword("password123!");
+        signUpRequest.setConfirmPassword("password123!");
+        signUpRequest.setRole(UserRole.USER);
+        signUpRequest.setPhone("01012345678");
+    }
+
+    // 회원가입 성공 - 신규 가입 (PENDING 상태, 인증 메일 발송)
+    @Test
+    @DisplayName("회원가입 성공 - 신규 가입, 인증 메일 발송")
+    void signUp_Success_NewUser_Pending() {
+        // Given
+        given(userRepository.findByEmail(signUpRequest.getEmail())).willReturn(Optional.empty());
+        given(passwordEncoder.encode(anyString())).willReturn("encoded_password");
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0);
+            savedUser.setId(1L);
+            return savedUser;
+        });
+
+        // When
+        UserResponse response = userService.signUp(signUpRequest);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getEmail()).isEqualTo(signUpRequest.getEmail());
+        verify(emailService, times(1)).sendSimpleEmail(
+                eq(signUpRequest.getEmail()),
+                contains("회원가입을 완료해주세요"),
+                contains("인증을 완료해주세요")
+        );
+    }
+
+    // 회원가입 실패 - 이미 ACTIVE 상태
+    @Test
+    @DisplayName("회원가입 실패 - 이미 ACTIVE 상태")
+    void signUp_Fail_ActiveUser() {
+        // Given
+        User existingUser = new User();
+        existingUser.setStatus(UserStatus.ACTIVE);
+        given(userRepository.findByEmail(signUpRequest.getEmail())).willReturn(Optional.of(existingUser));
+
+        // When & Then
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
+                userService.signUp(signUpRequest)
+        );
+        assertThat(thrown.getMessage()).isEqualTo("이미 사용 중인 이메일입니다.");
+        verify(emailService, never()).sendSimpleEmail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 - 비밀번호가 AOP에 의해 이미 암호화된 경우")
+    void signUp_Success_AOPEncryptedPassword() {
+        // Given
+        String preEncryptedPassword = "$2a$10$abcdefghijklmnopqrstuvwxyza.abcdefghijklmnopqrs.";
+        signUpRequest.setPassword(preEncryptedPassword);
+        signUpRequest.setConfirmPassword(preEncryptedPassword);
+
+        // findByEmail로 중복 체크 (이메일 없음)
+        given(userRepository.findByEmail(signUpRequest.getEmail())).willReturn(Optional.empty());
+
+        // passwordEncoder.encode()는 호출되지 않아야 함
+        // save 동작 mock
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User savedUser = invocation.getArgument(0);
+            savedUser.setId(2L);
+            savedUser.setStatus(UserStatus.ACTIVE);
+            savedUser.setPasswordChangedAt(LocalDateTime.now());
+            UserProfile userProfile = new UserProfile(savedUser, signUpRequest.getName(), signUpRequest.getName(), signUpRequest.getPhone());
+            savedUser.setUserProfile(userProfile);
+            // 비밀번호가 암호화된 값과 같은지 검증
+            assertThat(savedUser.getPassword()).isEqualTo(preEncryptedPassword);
+            return savedUser;
+        });
+
+        // When
+        UserResponse response = userService.signUp(signUpRequest);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getEmail()).isEqualTo(signUpRequest.getEmail());
+        assertThat(response.getRole()).isEqualTo(UserRole.USER);
+        assertThat(response.getUserId()).isEqualTo(2L);
+
+        // findByEmail만 호출됨
+        verify(userRepository, times(1)).findByEmail(signUpRequest.getEmail());
+        verify(passwordEncoder, times(0)).encode(anyString());
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    // 이메일 인증 성공
+    @Test
+    @DisplayName("이메일 인증 성공")
+    void verifyEmail_Success() {
+        // Given
+        String token = "valid-token";
+        User user = new User();
+        user.setStatus(UserStatus.PENDING);
+        user.setVerificationToken(token);
+        user.setVerificationTokenExpiry(LocalDateTime.now().plusMinutes(30));
+        given(userRepository.findByVerificationToken(token)).willReturn(Optional.of(user));
+
+        // When
+        userService.verifyEmail(token);
+
+        // Then
+        assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(user.getVerificationToken()).isNull();
+        assertThat(user.getVerificationTokenExpiry()).isNull();
+        verify(userRepository, times(1)).save(user);
+    }
+
+    // 이메일 인증 실패 - 만료된 토큰
+    @Test
+    @DisplayName("이메일 인증 실패 - 만료된 토큰")
+    void verifyEmail_Fail_ExpiredToken() {
+        // Given
+        String token = "expired-token";
+        User user = new User();
+        user.setStatus(UserStatus.PENDING);
+        user.setVerificationToken(token);
+        user.setVerificationTokenExpiry(LocalDateTime.now().minusMinutes(1));
+        given(userRepository.findByVerificationToken(token)).willReturn(Optional.of(user));
+
+        // When & Then
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+                userService.verifyEmail(token)
+        );
+        assertThat(thrown.getMessage()).contains("인증 토큰이 만료되었습니다");
+        verify(userRepository, times(1)).save(user);
+    }
+
+    // 이메일 인증 실패 - 잘못된 토큰
+    @Test
+    @DisplayName("이메일 인증 실패 - 잘못된 토큰")
+    void verifyEmail_Fail_InvalidToken() {
+        // Given
+        String token = "invalid-token";
+        given(userRepository.findByVerificationToken(token)).willReturn(Optional.empty());
+
+        // When & Then
+        RuntimeException thrown = assertThrows(RuntimeException.class, () ->
+                userService.verifyEmail(token)
+        );
+        assertThat(thrown.getMessage()).contains("유효하지 않거나 찾을 수 없는 인증 토큰");
+    }
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 이메일이 이미 존재하는 경우")
+    void isEmailDuplicated_True() {
+        // Given
+        String existingEmail = "duplicate@example.com";
+        given(userRepository.existsByEmail(existingEmail)).willReturn(true);
+
+        // When
+        boolean isDuplicated = userService.isEmailDuplicated(existingEmail);
+
+        // Then
+        assertThat(isDuplicated).isTrue();
+        verify(userRepository, times(1)).existsByEmail(existingEmail); // existsByEmail 호출 확인
+    }
+
+    @Test
+    @DisplayName("이메일 중복 확인 - 이메일이 존재하지 않는 경우")
+    void isEmailDuplicated_False() {
+        // Given
+        String newEmail = "new@example.com";
+        given(userRepository.existsByEmail(newEmail)).willReturn(false);
+
+        // When
+        boolean isDuplicated = userService.isEmailDuplicated(newEmail);
+
+        // Then
+        assertThat(isDuplicated).isFalse();
+        verify(userRepository, times(1)).existsByEmail(newEmail); // existsByEmail 호출 확인
+    }
+}


### PR DESCRIPTION
#29
주요 변경 사항

회원가입 시 이메일 중복 및 상태(PENDING, ACTIVE)별 처리 로직 추가
이미 ACTIVE 상태면 예외 발생
PENDING 상태면 인증 토큰 갱신 및 재인증 메일 발송
회원가입 시 loginId를 UUID로 자동 생성
비밀번호 암호화 처리
회원가입 시 User, UserProfile 엔티티 생성 및 저장
회원가입 완료 후 이메일 인증 링크 발송
이메일 인증 토큰 검증 및 계정 활성화 로직 추가
토큰 만료, 중복 인증 등 예외 처리
이메일/아이디 중복 확인 메서드 추가
이메일 전송은 EmailService 사용
UserService의 회원가입/이메일 인증 로직 변경에 맞춰 테스트 전체 리팩토링 및 케이스 보강
비밀번호가 이미 암호화된 경우(AOP 등) 처리 테스트 추가
이메일 인증 성공/실패(만료, 잘못된 토큰) 케이스 명확화
이메일 중복 확인 API 테스트 보강
BaseTimeEntity 상속 구조에 맞는 테스트 코드 반영(ReflectionTestUtils 등)<hr></hr>
이 PR은 회원가입 및 이메일 인증의 전체 플로우를 구현하며, 사용자 경험 및 보안성을 강화합니다.