### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: ./gradlew test --continue
         env:
           SPRING_PROFILES_ACTIVE: test
+          
 
 
       - name: Generate Test Coverage Report
@@ -50,6 +51,7 @@ jobs:
         run: ./gradlew build -x test
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}
 
       - name: Upload Test Results
         if: always()


### PR DESCRIPTION
백엔드 배포 주소인 APP_VERIFICATION_URL 추가

# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
백엔드 배포 환경에서 app.verification-url 설정 값이 누락되어 발생하던 빌드 실패 오류 해결

**Type**
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
GitHub Actions CI/CD 파이프라인의 Build Project 스텝에 APP_VERIFICATION_URL 환경 변수를 주입하도록 설정을 추가했습니다. 이는 GitHub Repository Secrets에 저장된 APP_VERIFICATION_URL 값을 참조합니다.

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
기존 GitHub Actions 빌드 워크플로우에서는 Spring Boot 애플리케이션의 UserService 빈 생성 시 필요한 app.verification-url 값을 찾지 못해 IllegalArgumentException (Could not resolve placeholder 'app.verification-url') 오류가 발생하며 빌드가 실패했습니다. 이 값은 사용자의 이메일 인증 등 백엔드 서비스의 특정 URL이 필요한 경우에 사용됩니다. 이 변경을 통해 CI/CD 환경에서 애플리케이션이 정상적으로 빌드될 수 있도록 합니다.
---

## 🔧 How (구현 방법)
### 주요 변경사항
- .github/workflows/spring-boot-ci.yml 파일의 Build Project (without tests) 스텝에 env 섹션을 추가하고 APP_VERIFICATION_URL 환경 변수를 정의했습니다.

### 기술적 접근
- GitHub Actions의 env 키워드를 사용하여 특정 스텝에 환경 변수를 주입했습니다.

- secrets.APP_VERIFICATION_URL 문법을 통해 GitHub Repository Secrets에 안전하게 저장된 값을 가져와 APP_VERIFICATION_URL 환경 변수로 할당했습니다.

- Spring Boot는 이 환경 변수를 app.verification-url 플레이스홀더로 자동 매핑하여 애플리케이션 빈 초기화 시점에 값을 사용할 수 있도록 합니다.

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
로컬에서 Gradle build 명령어를 통해 빌드 성공을 확인했습니다.

### 확인 사항
- [ ] 기능 정상 동작 확인
- [ ] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

---

## ✅ Checklist
- [ ] 코드 리뷰 준비 완료
- [ ] 테스트 완료
- [ ] 불필요한 로그 제거
