### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           SPRING_PROFILES_ACTIVE: test
           APP_VERIFICATION_URL: ${{ secrets.APP_VERIFICATION_URL }}
-
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
       - name: Generate Test Coverage Report
         run: ./gradlew jacocoTestReport
 


### PR DESCRIPTION
run test 시 jwt_secrets 추가

# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
CI 테스트 실행 시 JWT_SECRET 환경 변수 추가

**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [x] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->

- CI 워크플로우의 `Run Tests` 단계에 `JWT_SECRET` 환경 변수 추가
- 테스트 실행 시 JwtTokenProvider 빈 생성에 필요한 환경 변수 제공

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->

- CI 환경에서 테스트 실행 시 `JwtTokenProvider` 빈 생성 실패로 인한 빌드 오류 발생
- 로컬에서는 정상 동작하지만 CI에서만 실패하는 환경 차이 문제 해결
- `UnsatisfiedDependencyException` 오류로 인한 테스트 실패 해결

---

## 🔧 How (구현 방법)
### 주요 변경사항
- `.github/workflows/ci.yml` 파일 수정
- `Run Tests` 단계에 `JWT_SECRET: ${{ secrets.JWT_SECRET }}` 환경 변수 추가

### 기술적 접근
- 기존 `Build Project` 단계에서만 제공되던 JWT_SECRET을 테스트 단계에도 추가
- Organization secrets에 설정된 JWT_SECRET을 테스트 실행 시에도 사용할 수 있도록 설정


---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

### 확인 사항
- [ ] 기능 정상 동작 확인
- [ ] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

- 이 변경사항은 CI 환경에서만 적용되며, 로컬 개발 환경에는 영향을 주지 않습니다
- Organization secrets에 JWT_SECRET이 이미 설정되어 있어야 정상 동작합니다
- 향후 JWT 관련 테스트 추가 시에도 이 환경 변수를 활용할 수 있습니다
- 
---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [ ] 테스트 완료
- [ ] 불필요한 로그 제거
