### PR TITLE
MYCE-141 feat: 3요소(Cushion, SizeFit, Stability) 평가 통계 api 개발

### DIFF
--- a/src/main/java/com/cMall/feedShop/common/exception/BusinessException.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/BusinessException.java
@@ -16,6 +16,7 @@ public class BusinessException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+
     // errorCode 문자열 반환 (리뷰 서비스 호환용)
     public String getErrorCodeString() {
         return errorCode != null ? errorCode.getCode() : "UNKNOWN_ERROR";

--- a/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
@@ -58,7 +58,7 @@ public enum ErrorCode {
     EVENT_NOT_FOUND(404, "E001", "이벤트를 찾을 수 없습니다."),
     INVALID_EVENT_STATUS(400, "E002", "유효하지 않은 이벤트 상태입니다."),
     INVALID_EVENT_TYPE(400, "E003", "유효하지 않은 이벤트 타입입니다.");
-    
+
     private final int status;
     private final String code;
     private final String message;

--- a/src/main/java/com/cMall/feedShop/review/application/dto/response/Review3ElementStatisticsResponse.java
+++ b/src/main/java/com/cMall/feedShop/review/application/dto/response/Review3ElementStatisticsResponse.java
@@ -1,0 +1,51 @@
+package com.cMall.feedShop.review.application.dto.response;
+
+import com.cMall.feedShop.review.domain.enums.Cushion;
+import com.cMall.feedShop.review.domain.enums.SizeFit;
+import com.cMall.feedShop.review.domain.enums.Stability;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class Review3ElementStatisticsResponse {
+    private Long totalReviews;
+
+    // Cushion 통계
+    private CushionStatistics cushionStatistics;
+
+    // SizeFit 통계
+    private SizeFitStatistics sizeFitStatistics;
+
+    // Stability 통계
+    private StabilityStatistics stabilityStatistics;
+
+    @Getter
+    @Builder
+    public static class CushionStatistics {
+        private Map<Cushion, Long> distribution; // 각 옵션별 개수
+        private Map<Cushion, Double> percentage; // 각 옵션별 비율
+        private Cushion mostSelected; // 가장 많이 선택된 옵션
+        private Double averageScore; // 평균 점수 (1-5점으로 환산)
+    }
+
+    @Getter
+    @Builder
+    public static class SizeFitStatistics {
+        private Map<SizeFit, Long> distribution;
+        private Map<SizeFit, Double> percentage;
+        private SizeFit mostSelected;
+        private Double averageScore;
+    }
+
+    @Getter
+    @Builder
+    public static class StabilityStatistics {
+        private Map<Stability, Long> distribution;
+        private Map<Stability, Double> percentage;
+        private Stability mostSelected;
+        private Double averageScore;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/application/dto/response/ReviewCreateResponse.java
+++ b/src/main/java/com/cMall/feedShop/review/application/dto/response/ReviewCreateResponse.java
@@ -15,4 +15,5 @@ public class ReviewCreateResponse {
                 .message("리뷰가 성공적으로 작성되었습니다.")
                 .build();
     }
+
 }

--- a/src/main/java/com/cMall/feedShop/review/application/service/Review3ElementStatisticsService.java
+++ b/src/main/java/com/cMall/feedShop/review/application/service/Review3ElementStatisticsService.java
@@ -1,0 +1,186 @@
+package com.cMall.feedShop.review.application.service;
+
+import com.cMall.feedShop.review.application.dto.response.Review3ElementStatisticsResponse;
+import com.cMall.feedShop.review.domain.enums.Cushion;
+import com.cMall.feedShop.review.domain.enums.SizeFit;
+import com.cMall.feedShop.review.domain.enums.Stability;
+import com.cMall.feedShop.review.domain.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class Review3ElementStatisticsService {
+
+    private final ReviewRepository reviewRepository;
+
+    public Review3ElementStatisticsResponse getProductStatistics(Long productId) {
+        Long totalReviews = reviewRepository.countActiveReviewsByProductId(productId);
+
+        if (totalReviews == 0) {
+            return createEmptyStatistics();
+        }
+
+        // 각 요소별 분포 조회
+        Map<Cushion, Long> cushionDistribution = reviewRepository.getCushionDistributionByProductId(productId);
+        Map<SizeFit, Long> sizeFitDistribution = reviewRepository.getSizeFitDistributionByProductId(productId);
+        Map<Stability, Long> stabilityDistribution = reviewRepository.getStabilityDistributionByProductId(productId);
+
+        return Review3ElementStatisticsResponse.builder()
+                .totalReviews(totalReviews)
+                .cushionStatistics(buildCushionStatistics(cushionDistribution, totalReviews))
+                .sizeFitStatistics(buildSizeFitStatistics(sizeFitDistribution, totalReviews))
+                .stabilityStatistics(buildStabilityStatistics(stabilityDistribution, totalReviews))
+                .build();
+    }
+
+    private Review3ElementStatisticsResponse.CushionStatistics buildCushionStatistics(
+            Map<Cushion, Long> distribution, Long totalReviews) {
+
+        Map<Cushion, Double> percentage = calculatePercentages(distribution, totalReviews);
+        Cushion mostSelected = findMostSelected(distribution);
+        Double averageScore = calculateCushionAverageScore(distribution, totalReviews);
+
+        return Review3ElementStatisticsResponse.CushionStatistics.builder()
+                .distribution(distribution)
+                .percentage(percentage)
+                .mostSelected(mostSelected)
+                .averageScore(averageScore)
+                .build();
+    }
+
+    private Review3ElementStatisticsResponse.SizeFitStatistics buildSizeFitStatistics(
+            Map<SizeFit, Long> distribution, Long totalReviews) {
+
+        Map<SizeFit, Double> percentage = calculatePercentages(distribution, totalReviews);
+        SizeFit mostSelected = findMostSelected(distribution);
+        Double averageScore = calculateSizeFitAverageScore(distribution, totalReviews);
+
+        return Review3ElementStatisticsResponse.SizeFitStatistics.builder()
+                .distribution(distribution)
+                .percentage(percentage)
+                .mostSelected(mostSelected)
+                .averageScore(averageScore)
+                .build();
+    }
+
+    private Review3ElementStatisticsResponse.StabilityStatistics buildStabilityStatistics(
+            Map<Stability, Long> distribution, Long totalReviews) {
+
+        Map<Stability, Double> percentage = calculatePercentages(distribution, totalReviews);
+        Stability mostSelected = findMostSelected(distribution);
+        Double averageScore = calculateStabilityAverageScore(distribution, totalReviews);
+
+        return Review3ElementStatisticsResponse.StabilityStatistics.builder()
+                .distribution(distribution)
+                .percentage(percentage)
+                .mostSelected(mostSelected)
+                .averageScore(averageScore)
+                .build();
+    }
+
+    private <T> Map<T, Double> calculatePercentages(Map<T, Long> distribution, Long total) {
+        Map<T, Double> percentages = new HashMap<>();
+        distribution.forEach((key, count) -> {
+            double percentage = (count.doubleValue() / total.doubleValue()) * 100.0;
+            percentages.put(key, Math.round(percentage * 10.0) / 10.0); // 소수점 1자리
+        });
+        return percentages;
+    }
+
+    private <T> T findMostSelected(Map<T, Long> distribution) {
+        return distribution.entrySet().stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(null);
+    }
+
+    // Cushion을 1-5점으로 환산 (VERY_SOFT=1, SOFT=2, MEDIUM=3, FIRM=4, VERY_FIRM=5)
+    private Double calculateCushionAverageScore(Map<Cushion, Long> distribution, Long totalReviews) {
+        double totalScore = 0.0;
+        for (Map.Entry<Cushion, Long> entry : distribution.entrySet()) {
+            int score = getCushionScore(entry.getKey());
+            totalScore += score * entry.getValue();
+        }
+        return Math.round((totalScore / totalReviews) * 10.0) / 10.0;
+    }
+
+    // SizeFit을 1-5점으로 환산 (VERY_SMALL=1, SMALL=2, NORMAL=3, BIG=4, VERY_BIG=5)
+    private Double calculateSizeFitAverageScore(Map<SizeFit, Long> distribution, Long totalReviews) {
+        double totalScore = 0.0;
+        for (Map.Entry<SizeFit, Long> entry : distribution.entrySet()) {
+            int score = getSizeFitScore(entry.getKey());
+            totalScore += score * entry.getValue();
+        }
+        return Math.round((totalScore / totalReviews) * 10.0) / 10.0;
+    }
+
+    // Stability를 1-5점으로 환산 (VERY_UNSTABLE=1, UNSTABLE=2, NORMAL=3, STABLE=4, VERY_STABLE=5)
+    private Double calculateStabilityAverageScore(Map<Stability, Long> distribution, Long totalReviews) {
+        double totalScore = 0.0;
+        for (Map.Entry<Stability, Long> entry : distribution.entrySet()) {
+            int score = getStabilityScore(entry.getKey());
+            totalScore += score * entry.getValue();
+        }
+        return Math.round((totalScore / totalReviews) * 10.0) / 10.0;
+    }
+
+    private int getCushionScore(Cushion cushion) {
+        return switch (cushion) {
+            case VERY_SOFT -> 1;
+            case SOFT -> 2;
+            case MEDIUM -> 3;
+            case FIRM -> 4;
+            case VERY_FIRM -> 5;
+        };
+    }
+
+    private int getSizeFitScore(SizeFit sizeFit) {
+        return switch (sizeFit) {
+            case VERY_SMALL -> 1;
+            case SMALL -> 2;
+            case NORMAL -> 3;
+            case BIG -> 4;
+            case VERY_BIG -> 5;
+        };
+    }
+
+    private int getStabilityScore(Stability stability) {
+        return switch (stability) {
+            case VERY_UNSTABLE -> 1;
+            case UNSTABLE -> 2;
+            case NORMAL -> 3;
+            case STABLE -> 4;
+            case VERY_STABLE -> 5;
+        };
+    }
+
+    private Review3ElementStatisticsResponse createEmptyStatistics() {
+        return Review3ElementStatisticsResponse.builder()
+                .totalReviews(0L)
+                .cushionStatistics(Review3ElementStatisticsResponse.CushionStatistics.builder()
+                        .distribution(new HashMap<>())
+                        .percentage(new HashMap<>())
+                        .mostSelected(null)
+                        .averageScore(0.0)
+                        .build())
+                .sizeFitStatistics(Review3ElementStatisticsResponse.SizeFitStatistics.builder()
+                        .distribution(new HashMap<>())
+                        .percentage(new HashMap<>())
+                        .mostSelected(null)
+                        .averageScore(0.0)
+                        .build())
+                .stabilityStatistics(Review3ElementStatisticsResponse.StabilityStatistics.builder()
+                        .distribution(new HashMap<>())
+                        .percentage(new HashMap<>())
+                        .mostSelected(null)
+                        .averageScore(0.0)
+                        .build())
+                .build();
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/application/service/ReviewService.java
+++ b/src/main/java/com/cMall/feedShop/review/application/service/ReviewService.java
@@ -13,35 +13,42 @@ import com.cMall.feedShop.user.domain.model.User;
 import com.cMall.feedShop.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import com.cMall.feedShop.common.exception.ErrorCode;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
 
-    // 리뷰 생성
+    @Transactional
     public ReviewCreateResponse createReview(ReviewCreateRequest request) {
-        log.info("리뷰 생성 요청: 상품ID={}, 평점={}", request.getProductId(), request.getRating());
+        // SecurityContext에서 현재 로그인한 사용자 정보 가져오기
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        User currentUser = getCurrentUser();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
 
-        // TODO: SPRINT 2에서 주문 검증 로직 추가
-        // validateUserPurchasedProduct(currentUser.getId(), request.getProductId());
+        String userEmail = authentication.getName();
 
-        // TODO: SPRINT 2에서 중복 리뷰 검증 로직 추가
-        // validateNoDuplicateReview(currentUser.getId(), request.getProductId());
+        // 사용자 조회
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+        // 리뷰 생성
         Review review = Review.builder()
                 .title(request.getTitle())
                 .rating(request.getRating())
@@ -49,24 +56,29 @@ public class ReviewService {
                 .cushion(request.getCushion())
                 .stability(request.getStability())
                 .content(request.getContent())
-                .user(currentUser)
+                .user(user)
                 .productId(request.getProductId())
                 .build();
 
         Review savedReview = reviewRepository.save(review);
-        log.info("리뷰 생성 완료: ID={}", savedReview.getReviewId());
 
         return ReviewCreateResponse.of(savedReview.getReviewId());
     }
-
-    // 상품별 리뷰 목록 조회
+    /**
+     * 상품별 리뷰 목록 조회
+     * @param productId 상품 ID
+     * @param page 페이지 번호
+     * @param size 페이지 크기
+     * @param sort 정렬 방식
+     * @return 리뷰 목록 응답
+     */
     @Transactional(readOnly = true)
     public ReviewListResponse getProductReviews(Long productId, int page, int size, String sort) {
         log.info("상품 리뷰 목록 조회: 상품ID={}, 페이지={}, 크기={}, 정렬={}", productId, page, size, sort);
 
-        // 페이지 검증
-        if (page < 0) page = 0;
-        if (size < 1 || size > 100) size = 20;
+        // 페이지 검증 및 기본값 설정
+        page = Math.max(0, page);
+        size = (size < 1 || size > 100) ? 20 : size;
 
         Pageable pageable = PageRequest.of(page, size);
 
@@ -88,7 +100,11 @@ public class ReviewService {
         return ReviewListResponse.of(reviewResponsePage, averageRating, totalReviews);
     }
 
-    // 리뷰 상세 조회
+    /**
+     * 리뷰 상세 조회
+     * @param reviewId 리뷰 ID
+     * @return 리뷰 상세 응답
+     */
     @Transactional(readOnly = true)
     public ReviewResponse getReview(Long reviewId) {
         log.info("리뷰 상세 조회: ID={}", reviewId);
@@ -103,15 +119,86 @@ public class ReviewService {
         return ReviewResponse.from(review);
     }
 
-    // 현재 사용자 조회
-    private User getCurrentUser() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
+    /**
+     * JWT에서 현재 사용자 조회
+     * @param userDetails 사용자 인증 정보
+     * @return 현재 사용자
+     */
+    private User getCurrentUser(UserDetails userDetails) {
+        if (userDetails == null) {
             throw new BusinessException(ErrorCode.UNAUTHORIZED, "로그인이 필요합니다.");
         }
 
-        String email = authentication.getName();
+        String email = userDetails.getUsername();
         return userRepository.findByEmail(email)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
     }
+
+    // TODO: SPRINT 2에서 추가 예정 메서드들
+    /*
+    private void validateUserPurchasedProduct(Long userId, Long productId) {
+        // 사용자가 해당 상품을 구매했는지 검증
+        boolean hasPurchased = orderService.hasUserPurchasedProduct(userId, productId);
+        if (!hasPurchased) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "구매한 상품에 대해서만 리뷰를 작성할 수 있습니다.");
+        }
+    }
+
+    private void validateNoDuplicateReview(Long userId, Long productId) {
+        // 이미 해당 상품에 대한 리뷰를 작성했는지 검증
+        boolean hasReviewed = reviewRepository.existsByUserIdAndProductId(userId, productId);
+        if (hasReviewed) {
+            throw new DuplicateReviewException();
+        }
+    }
+
+    @Transactional
+    public void updateReview(Long reviewId, ReviewUpdateRequest request, UserDetails userDetails) {
+        User currentUser = getCurrentUser(userDetails);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+
+        if (!review.isOwnedBy(currentUser.getId())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인이 작성한 리뷰만 수정할 수 있습니다.");
+        }
+
+        review.update(request.getTitle(), request.getRating(), request.getContent(),
+                     request.getSizeFit(), request.getCushion(), request.getStability());
+
+        reviewRepository.save(review);
+    }
+
+    @Transactional
+    public void deleteReview(Long reviewId, UserDetails userDetails) {
+        User currentUser = getCurrentUser(userDetails);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+
+        if (!review.isOwnedBy(currentUser.getId())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인이 작성한 리뷰만 삭제할 수 있습니다.");
+        }
+
+        review.delete();
+        reviewRepository.save(review);
+    }
+
+    @Transactional
+    public void addReviewPoint(Long reviewId, UserDetails userDetails) {
+        User currentUser = getCurrentUser(userDetails);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException("리뷰를 찾을 수 없습니다."));
+
+        // 자신의 리뷰에는 추천할 수 없음
+        if (review.isOwnedBy(currentUser.getId())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN, "본인이 작성한 리뷰에는 추천할 수 없습니다.");
+        }
+
+        // TODO: 추천 중복 방지 로직 추가
+        review.addPoint();
+        reviewRepository.save(review);
+    }
+    */
 }

--- a/src/main/java/com/cMall/feedShop/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/repository/ReviewRepository.java
@@ -1,9 +1,14 @@
+// 1. ReviewRepository 인터페이스 (전체)
 package com.cMall.feedShop.review.domain.repository;
 
 import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.enums.Cushion;
+import com.cMall.feedShop.review.domain.enums.SizeFit;
+import com.cMall.feedShop.review.domain.enums.Stability;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Map;
 import java.util.Optional;
 
 public interface ReviewRepository {
@@ -24,4 +29,9 @@ public interface ReviewRepository {
 
     // 상품별 리뷰 개수
     Long countActiveReviewsByProductId(Long productId);
+
+    // ========== 새로 추가: 3요소 통계를 위한 메서드들 ==========
+    Map<Cushion, Long> getCushionDistributionByProductId(Long productId);
+    Map<SizeFit, Long> getSizeFitDistributionByProductId(Long productId);
+    Map<Stability, Long> getStabilityDistributionByProductId(Long productId);
 }

--- a/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewJpaRepository.java
+++ b/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewJpaRepository.java
@@ -8,7 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
+
+    // ========== 기존 쿼리들 ==========
 
     // 상품별 활성 리뷰 조회 (최신순)
     @Query("SELECT r FROM Review r WHERE r.productId = :productId AND r.status = 'ACTIVE' AND r.isBlinded = false ORDER BY r.createdAt DESC")
@@ -25,4 +29,15 @@ public interface ReviewJpaRepository extends JpaRepository<Review, Long> {
     // 상품별 리뷰 개수
     @Query("SELECT COUNT(r) FROM Review r WHERE r.productId = :productId AND r.status = 'ACTIVE' AND r.isBlinded = false")
     Long countActiveReviewsByProductId(@Param("productId") Long productId);
+
+    // ========== 새로 추가: 3요소 통계 쿼리들 ==========
+
+    @Query("SELECT r.cushion, COUNT(r) FROM Review r WHERE r.productId = :productId AND r.status = 'ACTIVE' AND r.isBlinded = false GROUP BY r.cushion")
+    List<Object[]> findCushionDistributionByProductId(@Param("productId") Long productId);
+
+    @Query("SELECT r.sizeFit, COUNT(r) FROM Review r WHERE r.productId = :productId AND r.status = 'ACTIVE' AND r.isBlinded = false GROUP BY r.sizeFit")
+    List<Object[]> findSizeFitDistributionByProductId(@Param("productId") Long productId);
+
+    @Query("SELECT r.stability, COUNT(r) FROM Review r WHERE r.productId = :productId AND r.status = 'ACTIVE' AND r.isBlinded = false GROUP BY r.stability")
+    List<Object[]> findStabilityDistributionByProductId(@Param("productId") Long productId);
 }

--- a/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewRepositoryImpl.java
@@ -1,19 +1,27 @@
 package com.cMall.feedShop.review.infrastructure.repository;
 
 import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.enums.Cushion;
+import com.cMall.feedShop.review.domain.enums.SizeFit;
+import com.cMall.feedShop.review.domain.enums.Stability;
 import com.cMall.feedShop.review.domain.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
 public class ReviewRepositoryImpl implements ReviewRepository {
 
     private final ReviewJpaRepository reviewJpaRepository;
+
+    // ========== 기존 메서드들 ==========
 
     @Override
     public Review save(Review review) {
@@ -48,5 +56,37 @@ public class ReviewRepositoryImpl implements ReviewRepository {
     @Override
     public Long countActiveReviewsByProductId(Long productId) {
         return reviewJpaRepository.countActiveReviewsByProductId(productId);
+    }
+
+    // ========== 새로 추가: 3요소 통계 메서드들 ==========
+
+    @Override
+    public Map<Cushion, Long> getCushionDistributionByProductId(Long productId) {
+        List<Object[]> results = reviewJpaRepository.findCushionDistributionByProductId(productId);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        result -> (Cushion) result[0],
+                        result -> (Long) result[1]
+                ));
+    }
+
+    @Override
+    public Map<SizeFit, Long> getSizeFitDistributionByProductId(Long productId) {
+        List<Object[]> results = reviewJpaRepository.findSizeFitDistributionByProductId(productId);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        result -> (SizeFit) result[0],
+                        result -> (Long) result[1]
+                ));
+    }
+
+    @Override
+    public Map<Stability, Long> getStabilityDistributionByProductId(Long productId) {
+        List<Object[]> results = reviewJpaRepository.findStabilityDistributionByProductId(productId);
+        return results.stream()
+                .collect(Collectors.toMap(
+                        result -> (Stability) result[0],
+                        result -> (Long) result[1]
+                ));
     }
 }

--- a/src/main/java/com/cMall/feedShop/review/presentation/ReviewController.java
+++ b/src/main/java/com/cMall/feedShop/review/presentation/ReviewController.java
@@ -2,8 +2,10 @@ package com.cMall.feedShop.review.presentation;
 
 import com.cMall.feedShop.common.aop.ApiResponseFormat;
 import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.review.application.dto.response.Review3ElementStatisticsResponse;
 import com.cMall.feedShop.review.application.dto.response.ReviewListResponse;
 import com.cMall.feedShop.review.application.dto.response.ReviewResponse;
+import com.cMall.feedShop.review.application.service.Review3ElementStatisticsService;
 import com.cMall.feedShop.review.application.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class ReviewController {
 
     private final ReviewService reviewService;
-
+    private final Review3ElementStatisticsService statisticsService;
     @GetMapping("/products/{productId}")
     @ApiResponseFormat(message = "상품 리뷰 목록을 성공적으로 조회했습니다.")
     @Operation(summary = "상품별 리뷰 목록 조회", description = "특정 상품의 리뷰 목록을 조회합니다. 로그인이 필요하지 않습니다.")
@@ -37,6 +39,16 @@ public class ReviewController {
     public ApiResponse<ReviewResponse> getReview(
             @Parameter(description = "리뷰 ID") @PathVariable Long reviewId) {
         ReviewResponse response = reviewService.getReview(reviewId);
+        return ApiResponse.success(response);
+    }
+
+    @GetMapping("/products/{productId}/statistics")
+    @ApiResponseFormat(message = "상품 3요소 평가 통계를 성공적으로 조회했습니다.")
+    @Operation(summary = "상품별 3요소 평가 통계 조회",
+            description = "특정 상품의 Cushion, SizeFit, Stability 평가 통계를 조회합니다. 로그인이 필요하지 않습니다.")
+    public ApiResponse<Review3ElementStatisticsResponse> getProductStatistics(
+            @Parameter(description = "상품 ID") @PathVariable Long productId) {
+        Review3ElementStatisticsResponse response = statisticsService.getProductStatistics(productId);
         return ApiResponse.success(response);
     }
 }

--- a/src/test/java/com/cMall/feedShop/review/application/service/Review3ElementStatisticsServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/review/application/service/Review3ElementStatisticsServiceTest.java
@@ -1,0 +1,173 @@
+package com.cMall.feedShop.review.application.service;
+
+import com.cMall.feedShop.review.application.dto.response.Review3ElementStatisticsResponse;
+import com.cMall.feedShop.review.domain.enums.Cushion;
+import com.cMall.feedShop.review.domain.enums.SizeFit;
+import com.cMall.feedShop.review.domain.enums.Stability;
+import com.cMall.feedShop.review.domain.repository.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("Review3ElementStatisticsService 테스트")
+class Review3ElementStatisticsServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @InjectMocks
+    private Review3ElementStatisticsService statisticsService;
+
+    private Long productId;
+    private Long totalReviews;
+    private Map<Cushion, Long> cushionDistribution;
+    private Map<SizeFit, Long> sizeFitDistribution;
+    private Map<Stability, Long> stabilityDistribution;
+
+    @BeforeEach
+    void setUp() {
+        productId = 1L;
+        totalReviews = 10L;
+
+        // Cushion 분포: SOFT=3, MEDIUM=4, FIRM=3
+        cushionDistribution = new HashMap<>();
+        cushionDistribution.put(Cushion.SOFT, 3L);
+        cushionDistribution.put(Cushion.MEDIUM, 4L);
+        cushionDistribution.put(Cushion.FIRM, 3L);
+
+        // SizeFit 분포: SMALL=2, NORMAL=6, BIG=2
+        sizeFitDistribution = new HashMap<>();
+        sizeFitDistribution.put(SizeFit.SMALL, 2L);
+        sizeFitDistribution.put(SizeFit.NORMAL, 6L);
+        sizeFitDistribution.put(SizeFit.BIG, 2L);
+
+        // Stability 분포: NORMAL=3, STABLE=5, VERY_STABLE=2
+        stabilityDistribution = new HashMap<>();
+        stabilityDistribution.put(Stability.NORMAL, 3L);
+        stabilityDistribution.put(Stability.STABLE, 5L);
+        stabilityDistribution.put(Stability.VERY_STABLE, 2L);
+    }
+
+    @Test
+    @DisplayName("정상적인 통계 데이터가 주어졌을때_getProductStatistics 호출하면_올바른 통계가 반환된다")
+    void givenValidStatisticsData_whenGetProductStatistics_thenReturnCorrectStatistics() {
+        // given
+        given(reviewRepository.countActiveReviewsByProductId(productId)).willReturn(totalReviews);
+        given(reviewRepository.getCushionDistributionByProductId(productId)).willReturn(cushionDistribution);
+        given(reviewRepository.getSizeFitDistributionByProductId(productId)).willReturn(sizeFitDistribution);
+        given(reviewRepository.getStabilityDistributionByProductId(productId)).willReturn(stabilityDistribution);
+
+        // when
+        Review3ElementStatisticsResponse result = statisticsService.getProductStatistics(productId);
+
+        // then
+        assertThat(result.getTotalReviews()).isEqualTo(10L);
+
+        // Cushion 통계 검증
+        assertThat(result.getCushionStatistics().getDistribution()).isEqualTo(cushionDistribution);
+        assertThat(result.getCushionStatistics().getMostSelected()).isEqualTo(Cushion.MEDIUM); // 4개로 가장 많음
+        assertThat(result.getCushionStatistics().getPercentage().get(Cushion.MEDIUM)).isEqualTo(40.0); // 4/10 * 100
+        assertThat(result.getCushionStatistics().getAverageScore()).isEqualTo(3.0); // (2*3 + 3*4 + 4*3) / 10 = 30/10 = 3.0
+
+        // SizeFit 통계 검증
+        assertThat(result.getSizeFitStatistics().getDistribution()).isEqualTo(sizeFitDistribution);
+        assertThat(result.getSizeFitStatistics().getMostSelected()).isEqualTo(SizeFit.NORMAL); // 6개로 가장 많음
+        assertThat(result.getSizeFitStatistics().getPercentage().get(SizeFit.NORMAL)).isEqualTo(60.0); // 6/10 * 100
+        assertThat(result.getSizeFitStatistics().getAverageScore()).isEqualTo(3.0); // (2*2 + 3*6 + 4*2) / 10 = 30/10 = 3.0
+
+        // Stability 통계 검증
+        assertThat(result.getStabilityStatistics().getDistribution()).isEqualTo(stabilityDistribution);
+        assertThat(result.getStabilityStatistics().getMostSelected()).isEqualTo(Stability.STABLE); // 5개로 가장 많음
+        assertThat(result.getStabilityStatistics().getPercentage().get(Stability.STABLE)).isEqualTo(50.0); // 5/10 * 100
+        assertThat(result.getStabilityStatistics().getAverageScore()).isEqualTo(3.9); // (3*3 + 4*5 + 5*2) / 10 = 39/10 = 3.9
+
+        verify(reviewRepository, times(1)).countActiveReviewsByProductId(productId);
+        verify(reviewRepository, times(1)).getCushionDistributionByProductId(productId);
+        verify(reviewRepository, times(1)).getSizeFitDistributionByProductId(productId);
+        verify(reviewRepository, times(1)).getStabilityDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("리뷰가 없는 상품일때_getProductStatistics 호출하면_빈 통계가 반환된다")
+    void givenNoReviews_whenGetProductStatistics_thenReturnEmptyStatistics() {
+        // given
+        given(reviewRepository.countActiveReviewsByProductId(productId)).willReturn(0L);
+
+        // when
+        Review3ElementStatisticsResponse result = statisticsService.getProductStatistics(productId);
+
+        // then
+        assertThat(result.getTotalReviews()).isEqualTo(0L);
+        assertThat(result.getCushionStatistics().getDistribution()).isEmpty();
+        assertThat(result.getCushionStatistics().getMostSelected()).isNull();
+        assertThat(result.getCushionStatistics().getAverageScore()).isEqualTo(0.0);
+        assertThat(result.getSizeFitStatistics().getDistribution()).isEmpty();
+        assertThat(result.getStabilityStatistics().getDistribution()).isEmpty();
+
+        verify(reviewRepository, times(1)).countActiveReviewsByProductId(productId);
+        verify(reviewRepository, times(0)).getCushionDistributionByProductId(productId); // 호출되지 않아야 함
+    }
+
+    @Test
+    @DisplayName("한개 옵션만 선택된 경우_getProductStatistics 호출하면_100퍼센트 통계가 반환된다")
+    void givenSingleOptionSelected_whenGetProductStatistics_thenReturn100PercentStatistics() {
+        // given
+        Map<Cushion, Long> singleCushionDistribution = new HashMap<>();
+        singleCushionDistribution.put(Cushion.MEDIUM, 5L);
+
+        Map<SizeFit, Long> singleSizeFitDistribution = new HashMap<>();
+        singleSizeFitDistribution.put(SizeFit.NORMAL, 5L);
+
+        Map<Stability, Long> singleStabilityDistribution = new HashMap<>();
+        singleStabilityDistribution.put(Stability.STABLE, 5L);
+
+        given(reviewRepository.countActiveReviewsByProductId(productId)).willReturn(5L);
+        given(reviewRepository.getCushionDistributionByProductId(productId)).willReturn(singleCushionDistribution);
+        given(reviewRepository.getSizeFitDistributionByProductId(productId)).willReturn(singleSizeFitDistribution);
+        given(reviewRepository.getStabilityDistributionByProductId(productId)).willReturn(singleStabilityDistribution);
+
+        // when
+        Review3ElementStatisticsResponse result = statisticsService.getProductStatistics(productId);
+
+        // then
+        assertThat(result.getTotalReviews()).isEqualTo(5L);
+        assertThat(result.getCushionStatistics().getPercentage().get(Cushion.MEDIUM)).isEqualTo(100.0);
+        assertThat(result.getCushionStatistics().getMostSelected()).isEqualTo(Cushion.MEDIUM);
+        assertThat(result.getSizeFitStatistics().getPercentage().get(SizeFit.NORMAL)).isEqualTo(100.0);
+        assertThat(result.getStabilityStatistics().getPercentage().get(Stability.STABLE)).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("극값들이 포함된 분포일때_getProductStatistics 호출하면_올바른 평균이 계산된다")
+    void givenExtremeValues_whenGetProductStatistics_thenCalculateCorrectAverage() {
+        // given - 극값들 포함 (VERY_SOFT=1점, VERY_FIRM=5점)
+        Map<Cushion, Long> extremeCushionDistribution = new HashMap<>();
+        extremeCushionDistribution.put(Cushion.VERY_SOFT, 1L); // 1점
+        extremeCushionDistribution.put(Cushion.VERY_FIRM, 1L); // 5점
+
+        given(reviewRepository.countActiveReviewsByProductId(productId)).willReturn(2L);
+        given(reviewRepository.getCushionDistributionByProductId(productId)).willReturn(extremeCushionDistribution);
+        given(reviewRepository.getSizeFitDistributionByProductId(productId)).willReturn(new HashMap<>());
+        given(reviewRepository.getStabilityDistributionByProductId(productId)).willReturn(new HashMap<>());
+
+        // when
+        Review3ElementStatisticsResponse result = statisticsService.getProductStatistics(productId);
+
+        // then
+        // (1*1 + 5*1) / 2 = 6/2 = 3.0
+        assertThat(result.getCushionStatistics().getAverageScore()).isEqualTo(3.0);
+    }
+}

--- a/src/test/java/com/cMall/feedShop/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/review/application/service/ReviewServiceTest.java
@@ -136,7 +136,7 @@ class ReviewServiceTest {
             // when & then
             assertThatThrownBy(() -> reviewService.createReview(createRequest))
                     .isInstanceOf(BusinessException.class)
-                    .hasMessageContaining("로그인이 필요합니다");
+                    .hasMessageContaining("인증이 필요합니다");
         }
     }
 

--- a/src/test/java/com/cMall/feedShop/review/infrastructure/repository/ReviewRepositoryImplStatisticsTest.java
+++ b/src/test/java/com/cMall/feedShop/review/infrastructure/repository/ReviewRepositoryImplStatisticsTest.java
@@ -1,0 +1,279 @@
+package com.cMall.feedShop.review.infrastructure.repository;
+
+import com.cMall.feedShop.review.domain.enums.Cushion;
+import com.cMall.feedShop.review.domain.enums.SizeFit;
+import com.cMall.feedShop.review.domain.enums.Stability;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReviewRepositoryImpl 통계 메서드 테스트")
+class ReviewRepositoryImplStatisticsTest {
+
+    @Mock
+    private ReviewJpaRepository reviewJpaRepository;
+
+    @InjectMocks
+    private ReviewRepositoryImpl reviewRepository;
+
+    @Test
+    @DisplayName("Cushion 분포 조회가 주어졌을때_getCushionDistributionByProductId 호출하면_Map으로 변환되어 반환된다")
+    void givenCushionDistribution_whenGetCushionDistributionByProductId_thenReturnMap() {
+        // given
+        Long productId = 1L;
+        List<Object[]> queryResults = Arrays.<Object[]>asList(
+                new Object[]{Cushion.SOFT, 3L},
+                new Object[]{Cushion.MEDIUM, 5L},
+                new Object[]{Cushion.FIRM, 2L}
+        );
+        given(reviewJpaRepository.findCushionDistributionByProductId(productId)).willReturn(queryResults);
+
+        // when
+        Map<Cushion, Long> result = reviewRepository.getCushionDistributionByProductId(productId);
+
+        // then
+        assertThat(result)
+                .hasSize(3)
+                .containsEntry(Cushion.SOFT, 3L)
+                .containsEntry(Cushion.MEDIUM, 5L)
+                .containsEntry(Cushion.FIRM, 2L);
+        verify(reviewJpaRepository, times(1)).findCushionDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("SizeFit 분포 조회가 주어졌을때_getSizeFitDistributionByProductId 호출하면_Map으로 변환되어 반환된다")
+    void givenSizeFitDistribution_whenGetSizeFitDistributionByProductId_thenReturnMap() {
+        // given
+        Long productId = 1L;
+        List<Object[]> queryResults = Arrays.<Object[]>asList(
+                new Object[]{SizeFit.SMALL, 2L},
+                new Object[]{SizeFit.NORMAL, 6L},
+                new Object[]{SizeFit.BIG, 1L}
+        );
+        given(reviewJpaRepository.findSizeFitDistributionByProductId(productId)).willReturn(queryResults);
+
+        // when
+        Map<SizeFit, Long> result = reviewRepository.getSizeFitDistributionByProductId(productId);
+
+        // then
+        assertThat(result)
+                .hasSize(3)
+                .containsEntry(SizeFit.SMALL, 2L)
+                .containsEntry(SizeFit.NORMAL, 6L)
+                .containsEntry(SizeFit.BIG, 1L);
+        verify(reviewJpaRepository, times(1)).findSizeFitDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("Stability 분포 조회가 주어졌을때_getStabilityDistributionByProductId 호출하면_Map으로 변환되어 반환된다")
+    void givenStabilityDistribution_whenGetStabilityDistributionByProductId_thenReturnMap() {
+        // given
+        Long productId = 1L;
+        List<Object[]> queryResults = Arrays.<Object[]>asList(
+                new Object[]{Stability.NORMAL, 1L},
+                new Object[]{Stability.STABLE, 4L},
+                new Object[]{Stability.VERY_STABLE, 3L}
+        );
+        given(reviewJpaRepository.findStabilityDistributionByProductId(productId)).willReturn(queryResults);
+
+        // when
+        Map<Stability, Long> result = reviewRepository.getStabilityDistributionByProductId(productId);
+
+        // then
+        assertThat(result)
+                .hasSize(3)
+                .containsEntry(Stability.NORMAL, 1L)
+                .containsEntry(Stability.STABLE, 4L)
+                .containsEntry(Stability.VERY_STABLE, 3L);
+        verify(reviewJpaRepository, times(1)).findStabilityDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("빈 결과가 주어졌을때_통계 분포 조회하면_빈 Map이 반환된다")
+    void givenEmptyResults_whenGetDistribution_thenReturnEmptyMap() {
+        // given
+        Long productId = 999L;
+        given(reviewJpaRepository.findCushionDistributionByProductId(productId)).willReturn(Collections.emptyList());
+
+        // when
+        Map<Cushion, Long> result = reviewRepository.getCushionDistributionByProductId(productId);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(reviewJpaRepository, times(1)).findCushionDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("여러개 Cushion 옵션이 주어졌을때_getCushionDistributionByProductId 호출하면_모든 옵션이 포함된 Map이 반환된다")
+    void givenMultipleCushionOptions_whenGetCushionDistributionByProductId_thenReturnCompleteMap() {
+        // given
+        Long productId = 1L;
+        List<Object[]> queryResults = Arrays.<Object[]>asList(
+                new Object[]{Cushion.VERY_SOFT, 1L},
+                new Object[]{Cushion.SOFT, 2L},
+                new Object[]{Cushion.MEDIUM, 4L},
+                new Object[]{Cushion.FIRM, 2L},
+                new Object[]{Cushion.VERY_FIRM, 1L}
+        );
+        given(reviewJpaRepository.findCushionDistributionByProductId(productId)).willReturn(queryResults);
+
+        // when
+        Map<Cushion, Long> result = reviewRepository.getCushionDistributionByProductId(productId);
+
+        // then
+        assertThat(result)
+                .hasSize(5)
+                .containsEntry(Cushion.VERY_SOFT, 1L)
+                .containsEntry(Cushion.SOFT, 2L)
+                .containsEntry(Cushion.MEDIUM, 4L)
+                .containsEntry(Cushion.FIRM, 2L)
+                .containsEntry(Cushion.VERY_FIRM, 1L);
+        verify(reviewJpaRepository, times(1)).findCushionDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("여러개 SizeFit 옵션이 주어졌을때_getSizeFitDistributionByProductId 호출하면_모든 옵션이 포함된 Map이 반환된다")
+    void givenMultipleSizeFitOptions_whenGetSizeFitDistributionByProductId_thenReturnCompleteMap() {
+        // given
+        Long productId = 1L;
+        List<Object[]> queryResults = Arrays.<Object[]>asList(
+                new Object[]{SizeFit.VERY_SMALL, 1L},
+                new Object[]{SizeFit.SMALL, 2L},
+                new Object[]{SizeFit.NORMAL, 5L},
+                new Object[]{SizeFit.BIG, 1L},
+                new Object[]{SizeFit.VERY_BIG, 1L}
+        );
+        given(reviewJpaRepository.findSizeFitDistributionByProductId(productId)).willReturn(queryResults);
+
+        // when
+        Map<SizeFit, Long> result = reviewRepository.getSizeFitDistributionByProductId(productId);
+
+        // then
+        assertThat(result)
+                .hasSize(5)
+                .containsEntry(SizeFit.VERY_SMALL, 1L)
+                .containsEntry(SizeFit.SMALL, 2L)
+                .containsEntry(SizeFit.NORMAL, 5L)
+                .containsEntry(SizeFit.BIG, 1L)
+                .containsEntry(SizeFit.VERY_BIG, 1L);
+        verify(reviewJpaRepository, times(1)).findSizeFitDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("여러개 Stability 옵션이 주어졌을때_getStabilityDistributionByProductId 호출하면_모든 옵션이 포함된 Map이 반환된다")
+    void givenMultipleStabilityOptions_whenGetStabilityDistributionByProductId_thenReturnCompleteMap() {
+        // given
+        Long productId = 1L;
+        List<Object[]> queryResults = Arrays.<Object[]>asList(
+                new Object[]{Stability.VERY_UNSTABLE, 1L},
+                new Object[]{Stability.UNSTABLE, 1L},
+                new Object[]{Stability.NORMAL, 2L},
+                new Object[]{Stability.STABLE, 4L},
+                new Object[]{Stability.VERY_STABLE, 2L}
+        );
+        given(reviewJpaRepository.findStabilityDistributionByProductId(productId)).willReturn(queryResults);
+
+        // when
+        Map<Stability, Long> result = reviewRepository.getStabilityDistributionByProductId(productId);
+
+        // then
+        assertThat(result)
+                .hasSize(5)
+                .containsEntry(Stability.VERY_UNSTABLE, 1L)
+                .containsEntry(Stability.UNSTABLE, 1L)
+                .containsEntry(Stability.NORMAL, 2L)
+                .containsEntry(Stability.STABLE, 4L)
+                .containsEntry(Stability.VERY_STABLE, 2L);
+        verify(reviewJpaRepository, times(1)).findStabilityDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("단일 옵션만 선택된 경우_각 분포 조회하면_해당 옵션만 포함된 Map이 반환된다")
+    void givenSingleOptionSelected_whenGetDistribution_thenReturnSingleEntryMap() {
+        // given
+        Long productId = 1L;
+
+        // Cushion에서 MEDIUM만 선택된 경우
+        List<Object[]> cushionResults = Arrays.<Object[]>asList(
+                new Object[]{Cushion.MEDIUM, 10L}
+        );
+        given(reviewJpaRepository.findCushionDistributionByProductId(productId)).willReturn(cushionResults);
+
+        // SizeFit에서 NORMAL만 선택된 경우
+        List<Object[]> sizeFitResults = Arrays.<Object[]>asList(
+                new Object[]{SizeFit.NORMAL, 10L}
+        );
+        given(reviewJpaRepository.findSizeFitDistributionByProductId(productId)).willReturn(sizeFitResults);
+
+        // Stability에서 STABLE만 선택된 경우
+        List<Object[]> stabilityResults = Arrays.<Object[]>asList(
+                new Object[]{Stability.STABLE, 10L}
+        );
+        given(reviewJpaRepository.findStabilityDistributionByProductId(productId)).willReturn(stabilityResults);
+
+        // when
+        Map<Cushion, Long> cushionResult = reviewRepository.getCushionDistributionByProductId(productId);
+        Map<SizeFit, Long> sizeFitResult = reviewRepository.getSizeFitDistributionByProductId(productId);
+        Map<Stability, Long> stabilityResult = reviewRepository.getStabilityDistributionByProductId(productId);
+
+        // then
+        assertThat(cushionResult)
+                .hasSize(1)
+                .containsEntry(Cushion.MEDIUM, 10L);
+
+        assertThat(sizeFitResult)
+                .hasSize(1)
+                .containsEntry(SizeFit.NORMAL, 10L);
+
+        assertThat(stabilityResult)
+                .hasSize(1)
+                .containsEntry(Stability.STABLE, 10L);
+
+        verify(reviewJpaRepository, times(1)).findCushionDistributionByProductId(productId);
+        verify(reviewJpaRepository, times(1)).findSizeFitDistributionByProductId(productId);
+        verify(reviewJpaRepository, times(1)).findStabilityDistributionByProductId(productId);
+    }
+
+    @Test
+    @DisplayName("높은 개수의 분포가 주어졌을때_분포 조회하면_정확한 개수가 반환된다")
+    void givenHighCountDistribution_whenGetDistribution_thenReturnCorrectCounts() {
+        // given
+        Long productId = 1L;
+        List<Object[]> queryResults = Arrays.<Object[]>asList(
+                new Object[]{Cushion.SOFT, 1000L},
+                new Object[]{Cushion.MEDIUM, 2500L},
+                new Object[]{Cushion.FIRM, 1500L}
+        );
+        given(reviewJpaRepository.findCushionDistributionByProductId(productId)).willReturn(queryResults);
+
+        // when
+        Map<Cushion, Long> result = reviewRepository.getCushionDistributionByProductId(productId);
+
+        // then
+        assertThat(result)
+                .hasSize(3)
+                .containsEntry(Cushion.SOFT, 1000L)
+                .containsEntry(Cushion.MEDIUM, 2500L)
+                .containsEntry(Cushion.FIRM, 1500L);
+
+        // 총합 검증
+        Long totalCount = result.values().stream().mapToLong(Long::longValue).sum();
+        assertThat(totalCount).isEqualTo(5000L);
+
+        verify(reviewJpaRepository, times(1)).findCushionDistributionByProductId(productId);
+    }
+}

--- a/src/test/java/com/cMall/feedShop/review/infrastructure/repository/ReviewRepositoryImplTest.java
+++ b/src/test/java/com/cMall/feedShop/review/infrastructure/repository/ReviewRepositoryImplTest.java
@@ -20,7 +20,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -135,3 +137,4 @@ class ReviewRepositoryImplTest {
         verify(reviewJpaRepository, times(1)).countActiveReviewsByProductId(1L);
     }
 }
+


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!--  Summary
리뷰 3요소 평가 통계 API 구현 -->


**Type**
- [x ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

🎯 What & Why
무엇을 했나요?

상품별 리뷰의 3요소 평가 통계를 제공하는 API를 구현했습니다
GET /api/reviews/products/{productId}/statistics API를 통해 통계 데이터 제공
Cushion(쿠션감), SizeFit(사이즈 착용감), Stability(안정성) 각각의 분포 및 통계 계산
각 요소별 분포, 비율, 가장 많이 선택된 옵션, 평균 점수 제공

왜 필요했나요?

사용자가 상품 구매 전 다른 구매자들의 평가 경향을 파악할 수 있도록 지원
신발의 핵심 특성인 쿠션감, 사이즈감, 안정성에 대한 객관적 데이터 제공
개별 리뷰를 모두 읽지 않아도 전체적인 상품 특성을 한눈에 파악 가능
데이터 기반의 구매 의사결정 지원

---

🔧 How (구현 방법)
주요 변경사항

Review3ElementStatisticsResponse DTO 추가 (3요소 통계 응답 구조)
Review3ElementStatisticsService 서비스 클래스 구현
ReviewRepository에 3요소별 분포 조회 메서드 추가
ReviewController에 통계 조회 API 엔드포인트 추가
각 요소별 1-5점 점수 환산 및 평균 계산 로직 구현

---

기술적 접근

분포 조회: JPA 네이티브 쿼리로 각 요소별 GROUP BY 집계
비율 계산: 전체 리뷰 대비 각 옵션별 백분율 계산 (소수점 1자리)
평균 점수: 각 요소를 1-5점으로 환산하여 가중평균 계산

- Cushion: VERY_SOFT(1) ~ VERY_FIRM(5)

- SizeFit: VERY_SMALL(1) ~ VERY_BIG(5)

- Stability: VERY_UNSTABLE(1) ~ VERY_STABLE(5)


데이터 안전성: 리뷰가 없는 경우 빈 통계 객체 반환
성능 최적화: 단일 쿼리로 각 요소별 분포 조회
---
🧪 Testing
테스트 방법

단위 테스트를 통한 각 기능별 검증
정상 통계 데이터 시나리오 테스트
리뷰가 없는 상품 시나리오 테스트
단일 옵션만 선택된 경우 테스트
극값(VERY_SOFT, VERY_FIRM 등) 포함 평균 계산 테스트

확인 사항

통계 계산 로직 정확성 검증
비율 계산 및 반올림 처리 확인
빈 데이터 처리 안정성 확인
API 응답 형식 일관성 유지
---

## 📎 관련 이슈 / 문서
- 관련 이슈: #318 
- 지라 백로그: MYCE-141
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

활성 상태(ACTIVE)이고 블라인드 처리되지 않은 리뷰만 통계에 포함
각 요소별 평균 점수는 소수점 1자리로 반올림하여 제공
리뷰가 없는 상품의 경우 모든 값이 0 또는 빈 객체로 안전하게 처리
로그인 불필요한 공개 API로 구현
기존 리뷰 조회 API와 동일한 경로 구조 (/api/reviews/products/{productId}/...) 유지
---

## ✅ Checklist
- [x ] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x ] 불필요한 로그 제거
