### PR TITLE
MYCE-215 feat: 사용자 주문 상태 변경 API 구현

### DIFF
--- a/src/main/java/com/cMall/feedShop/order/application/service/OrderService.java
+++ b/src/main/java/com/cMall/feedShop/order/application/service/OrderService.java
@@ -265,44 +265,16 @@ public class OrderService {
         return OrderStatusUpdateResponse.from(order);
     }
 
+    // 판매자가 주문 상태를 변경할 수 있는지 검증한다.
     private void validateStatusUpdate(OrderStatus currentStatus, OrderStatus newStatus) {
-        // 주문된 상태에서만 배송중, 취소로 변경 가능하다
-        if (currentStatus == OrderStatus.ORDERED) {
-            // 배송중, 취소로만 변경 가능하다
-            if (newStatus != OrderStatus.SHIPPED && newStatus != OrderStatus.CANCELLED) {
-                throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
-            }
-        }
-        // 배송중 상태에서만 배송완료로 변경 가능하다
-        else if (currentStatus == OrderStatus.SHIPPED) {
-            // 배송완료로만 변경 가능하다
-            if (newStatus != OrderStatus.DELIVERED) {
-                throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
-            }
-        }
-        // 그 외 다른 상태에서는 변경이 불가능하다
-        else {
+        if (!currentStatus.canChangeTo(newStatus)) {
             throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
         }
     }
 
+    // 유저가 주문 상태를 변경할 수 있는지 검증한다.
     private void validateUserStatusUpdate(OrderStatus currentStatus, OrderStatus newStatus) {
-        // 주문된 상태에서만 취소가 가능하다
-        if (currentStatus == OrderStatus.ORDERED) {
-            // 취소로만 변경 가능하다
-            if (newStatus != OrderStatus.CANCELLED) {
-                throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
-            }
-        }
-        // 배송완료된 상태에서만 반품이 가능하다
-        else if (currentStatus == OrderStatus.DELIVERED) {
-            // 반품으로만 변경 가능하다
-            if (newStatus != OrderStatus.RETURNED) {
-                throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
-            }
-        }
-        // 그 외 다른 상태에서는 변경이 불가능하다
-        else {
+        if (!currentStatus.canUserChangeTo(newStatus)) {
             throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
         }
     }

--- a/src/main/java/com/cMall/feedShop/order/application/service/OrderService.java
+++ b/src/main/java/com/cMall/feedShop/order/application/service/OrderService.java
@@ -226,7 +226,7 @@ public class OrderService {
         User seller = getCurrentUserAndValidateSellerPermission(userDetails);
 
         // 2. 주문 조회 및 권한 검증
-        Order order = orderRepository.findByOrderIdAndSellerId(orderId, seller.getId())
+        Order order = orderRepository.findByOrderIdAndSeller(orderId, seller)
                 .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
 
         // 3. 상태 변경 가능 여부 검증
@@ -239,20 +239,69 @@ public class OrderService {
         return OrderStatusUpdateResponse.from(order);
     }
 
+    /**
+     * 사용자 주문 상태 변경
+     * @param orderId
+     * @param request
+     * @param userDetails
+     * @return
+     */
+    @Transactional
+    public OrderStatusUpdateResponse updateUserOrderStatus(Long orderId, OrderStatusUpdateRequest request, UserDetails userDetails) {
+        // 1. 현재 사용자 조회 및 권한 검증
+        User user = getCurrentUserAndValidatePermission(userDetails);
+
+        // 2. 주문 조회 및 권한 검증
+        Order order = orderRepository.findByOrderIdAndUser(orderId, user)
+                .orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
+
+        // 3. 상태 변경 가능 여부 검증
+        validateUserStatusUpdate(order.getStatus(), request.getStatus());
+
+        // 4. 주문 상태 업데이트
+        order.updateStatus(request.getStatus());
+
+        // 5. 주문 상태 변경 응답 반환
+        return OrderStatusUpdateResponse.from(order);
+    }
+
     private void validateStatusUpdate(OrderStatus currentStatus, OrderStatus newStatus) {
-        // 주문됨 -> 배송중, 취소로 변경 가능
+        // 주문된 상태에서만 배송중, 취소로 변경 가능하다
         if (currentStatus == OrderStatus.ORDERED) {
+            // 배송중, 취소로만 변경 가능하다
             if (newStatus != OrderStatus.SHIPPED && newStatus != OrderStatus.CANCELLED) {
                 throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
             }
         }
-        // 배송중 -> 배송완료로 변경 가능
+        // 배송중 상태에서만 배송완료로 변경 가능하다
         else if (currentStatus == OrderStatus.SHIPPED) {
+            // 배송완료로만 변경 가능하다
             if (newStatus != OrderStatus.DELIVERED) {
                 throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
             }
         }
-        // 배송완료, 취소됨, 반품됨 상태는 변경 불가
+        // 그 외 다른 상태에서는 변경이 불가능하다
+        else {
+            throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
+        }
+    }
+
+    private void validateUserStatusUpdate(OrderStatus currentStatus, OrderStatus newStatus) {
+        // 주문된 상태에서만 취소가 가능하다
+        if (currentStatus == OrderStatus.ORDERED) {
+            // 취소로만 변경 가능하다
+            if (newStatus != OrderStatus.CANCELLED) {
+                throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
+            }
+        }
+        // 배송완료된 상태에서만 반품이 가능하다
+        else if (currentStatus == OrderStatus.DELIVERED) {
+            // 반품으로만 변경 가능하다
+            if (newStatus != OrderStatus.RETURNED) {
+                throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
+            }
+        }
+        // 그 외 다른 상태에서는 변경이 불가능하다
         else {
             throw new OrderException(ErrorCode.INVALID_ORDER_STATUS);
         }

--- a/src/main/java/com/cMall/feedShop/order/domain/enums/OrderStatus.java
+++ b/src/main/java/com/cMall/feedShop/order/domain/enums/OrderStatus.java
@@ -1,9 +1,94 @@
 package com.cMall.feedShop.order.domain.enums;
 
+/**
+ * 주문 상태를 나타내는 열거형 클래스입니다.
+ * 각 상태에 따라 상태 변경 가능 여부를 정의합니다.
+ */
 public enum OrderStatus {
-    ORDERED,
-    SHIPPED,
-    DELIVERED,
-    CANCELLED,
-    RETURNED
+    // 주문됨
+    ORDERED {
+        // 판매자는 주문됨 상태에서
+        // 배송 중, 취소로 변경 가능하다.
+        @Override
+        public boolean canChangeTo(OrderStatus newStatus) {
+            return newStatus == SHIPPED || newStatus == CANCELLED;
+        }
+
+        // 유저는 주문됨 상태에서
+        // 취소로만 변경 가능하다.
+        @Override
+        public boolean canUserChangeTo(OrderStatus newStatus) {
+            return newStatus == CANCELLED;
+        }
+    },
+    // 배송중
+    SHIPPED {
+        // 판매자는 배송 중 상태에서
+        // 배송 완료로 변경 가능하다.
+        @Override
+        public boolean canChangeTo(OrderStatus newStatus) {
+            return newStatus == DELIVERED;
+        }
+
+        // 유저는 배송 중 상태에서
+        // 변경할 수 없다.
+        @Override
+        public boolean canUserChangeTo(OrderStatus newStatus) {
+            return false;
+        }
+    },
+    // 배송완료
+    DELIVERED {
+        // 판매자는 배송 완료 상태에서
+        // 반품으로 변경 가능하다.
+        @Override
+        public boolean canChangeTo(OrderStatus newStatus) {
+            return newStatus == RETURNED;
+        }
+
+        // 유저는 배송 완료 상태에서
+        // 반품으로 변경 가능하다.
+        @Override
+        public boolean canUserChangeTo(OrderStatus newStatus) {
+            return newStatus == RETURNED;
+        }
+    },
+    // 취소됨
+    CANCELLED {
+        // 판매자는 취소된 상태에서
+        // 변경할 수 없다.
+        @Override
+        public boolean canChangeTo(OrderStatus newStatus) {
+            return false;
+        }
+
+        // 유저는 취소된 상태에서
+        // 변경할 수 없다.
+        @Override
+        public boolean canUserChangeTo(OrderStatus newStatus) {
+            return false;
+        }
+    },
+    // 반품됨
+    RETURNED {
+        // 판매자는 반품된 상태에서
+        // 변경할 수 없다.
+        @Override
+        public boolean canChangeTo(OrderStatus newStatus) {
+            return false;
+        }
+
+        // 유저는 반품된 상태에서
+        // 변경할 수 없다.
+        @Override
+        public boolean canUserChangeTo(OrderStatus newStatus) {
+            return false;
+        }
+    };
+
+    // 판매자가 주문 상태 변경 가능 여부를 정의하는 메소드
+    public abstract boolean canChangeTo(OrderStatus newStatus);
+
+    // 유저가 주문 상태 변경 가능 여부를 정의하는 메소드
+    public abstract boolean canUserChangeTo(OrderStatus newStatus);
 }

--- a/src/main/java/com/cMall/feedShop/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/cMall/feedShop/order/domain/repository/OrderRepository.java
@@ -21,7 +21,12 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderQueryR
         return findByUserAndStatusOrderByCreatedAtDesc(user.getId(), status, pageable);
     }
 
-    // 특정 주문 ID에 해당하는 주문 + 내가 주문한 주문 을 찾는다. 단일 조회.
+    // 판매자 ID와 주문 ID로 주문을 찾는다.
+    default Optional<Order> findByOrderIdAndSeller(Long orderId, User seller) {
+        return findByOrderIdAndSellerId(orderId, seller.getId());
+    }
+
+    // 유저 ID로 주문 ID로 주문을 찾는다.
     default Optional<Order> findByOrderIdAndUser(Long orderId, User user) {
         return findByOrderIdAndUserId(orderId, user.getId());
     }

--- a/src/main/java/com/cMall/feedShop/order/infrastructure/repository/OrderQueryRepository.java
+++ b/src/main/java/com/cMall/feedShop/order/infrastructure/repository/OrderQueryRepository.java
@@ -20,9 +20,9 @@ public interface OrderQueryRepository {
     // 사용자별 + 상태별 주문 목록 조회 (EntityGraph 대체)
     Page<Order> findByUserAndStatusOrderByCreatedAtDesc(Long userId, OrderStatus status, Pageable pageable);
 
-    // 사용자별 특정 주문 조회 (EntityGraph 대체)
+    // 주문 ID와 유저 ID로 주문 조회
     Optional<Order> findByOrderIdAndUserId(Long orderId, Long userId);
 
-    // 주문 ID와 판매자 ID로 주문 조회 (판매자 권한 검증용)
+    // 주문 ID와 판매자 ID로 주문 조회
     Optional<Order> findByOrderIdAndSellerId(Long orderId, Long sellerId);
 }

--- a/src/main/java/com/cMall/feedShop/order/presentation/OrderUserController.java
+++ b/src/main/java/com/cMall/feedShop/order/presentation/OrderUserController.java
@@ -3,10 +3,8 @@ package com.cMall.feedShop.order.presentation;
 import com.cMall.feedShop.common.aop.ApiResponseFormat;
 import com.cMall.feedShop.common.dto.ApiResponse;
 import com.cMall.feedShop.order.application.dto.request.OrderCreateRequest;
-import com.cMall.feedShop.order.application.dto.response.OrderCreateResponse;
-import com.cMall.feedShop.order.application.dto.response.OrderDetailResponse;
-import com.cMall.feedShop.order.application.dto.response.OrderPageResponse;
-import com.cMall.feedShop.order.application.dto.response.PurchasedItemListResponse;
+import com.cMall.feedShop.order.application.dto.request.OrderStatusUpdateRequest;
+import com.cMall.feedShop.order.application.dto.response.*;
 import com.cMall.feedShop.order.application.service.OrderService;
 import com.cMall.feedShop.order.application.service.PurchasedItemService;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -111,5 +109,27 @@ public class OrderUserController {
     ) {
         PurchasedItemListResponse response = purchasedItemService.getPurchasedItems(userDetails);
         return ApiResponse.success(response);
+    }
+
+    /**
+     * 사용자 주문 상태 업데이트 API
+     * POST /api/users/orders/{orderId}/status
+     * 사용자가 자신의 상품 주문 상태를 변경 (취소, 반품)
+     * @param orderId
+     * @param request
+     * @param userDetails
+     * @return
+     */
+    @PostMapping("/orders/{orderId}/status")
+    @ApiResponseFormat(message = "주문 상태가 변경되었습니다.")
+    public ApiResponse<OrderStatusUpdateResponse> updateUserOrderStatus(
+            @PathVariable
+            @Min(value = 1, message = "주문 ID는 1 이상이어야 합니다.")
+            Long orderId,
+            @Valid @RequestBody OrderStatusUpdateRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+        ) {
+        OrderStatusUpdateResponse data = orderService.updateUserOrderStatus(orderId, request, userDetails);
+        return ApiResponse.success(data);
     }
 }

--- a/src/test/java/com/cMall/feedShop/order/application/service/OrderStatusTest.java
+++ b/src/test/java/com/cMall/feedShop/order/application/service/OrderStatusTest.java
@@ -1,0 +1,389 @@
+package com.cMall.feedShop.order.application.service;
+
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.order.application.dto.request.OrderStatusUpdateRequest;
+import com.cMall.feedShop.order.application.dto.response.OrderStatusUpdateResponse;
+import com.cMall.feedShop.order.domain.enums.OrderStatus;
+import com.cMall.feedShop.order.domain.model.Order;
+import com.cMall.feedShop.order.domain.exception.OrderException;
+import com.cMall.feedShop.order.domain.repository.OrderRepository;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * 🔍 초보자 설명:
+ * 이 테스트는 주문 상태 변경 기능이 올바르게 동작하는지 확인합니다.
+ * - 판매자가 주문 상태를 변경하는 경우
+ * - 사용자가 자신의 주문 상태를 변경하는 경우
+ * - 잘못된 상태 변경을 시도하는 경우
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("주문 상태 변경 테스트")
+class OrderStatusTest {
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserDetails userDetails;
+
+    @InjectMocks
+    private OrderService orderService;
+
+    // 테스트에서 사용할 기본 데이터들
+    private User sellerUser;  // 판매자 사용자
+    private User buyerUser;   // 구매자 사용자
+    private Order testOrder;  // 테스트용 주문
+    private OrderStatusUpdateRequest statusUpdateRequest;  // 상태 변경 요청
+
+    @BeforeEach
+    void setUp() {
+        // 판매자 사용자 생성 (상품을 파는 사람)
+        sellerUser = new User("seller123", "password", "seller@test.com", UserRole.SELLER);
+        ReflectionTestUtils.setField(sellerUser, "id", 1L);
+
+        // 구매자 사용자 생성 (상품을 사는 사람)
+        buyerUser = new User("buyer123", "password", "buyer@test.com", UserRole.USER);
+        ReflectionTestUtils.setField(buyerUser, "id", 2L);
+
+        // 기본 테스트 주문 생성 (주문됨 상태)
+        testOrder = Order.builder()
+                .user(buyerUser)               // 주문한 사용자
+                .status(OrderStatus.ORDERED)   // 처음엔 주문됨 상태
+                .totalPrice(BigDecimal.valueOf(50000))
+                .finalPrice(BigDecimal.valueOf(53000))
+                .deliveryFee(BigDecimal.valueOf(3000))
+                .recipientName("김구매자")
+                .recipientPhone("010-1234-5678")
+                .deliveryAddress("서울시 강남구")
+                .paymentMethod("카드")
+                .build();
+        ReflectionTestUtils.setField(testOrder, "orderId", 100L);
+
+        // UserDetails mock 설정 (로그인한 사용자 정보)
+        given(userDetails.getUsername()).willReturn("testuser");
+    }
+
+    /**
+     * 🏪 판매자 주문 상태 변경 테스트
+     * 판매자가 자신이 판매한 상품의 주문 상태를 변경하는 테스트
+     */
+    @Nested
+    @DisplayName("판매자 주문 상태 변경")
+    class SellerOrderStatusUpdate {
+
+        @Test
+        @DisplayName("성공: 주문됨 → 배송중으로 변경")
+        void updateOrderStatus_Success_OrderedToShipped() {
+            // Given: 주문을 배송중으로 변경하려는 상황
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.SHIPPED);
+
+            // Mock 설정: 판매자 조회 성공
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(sellerUser));
+            // Mock 설정: 주문 조회 성공 (판매자의 상품 주문)
+            given(orderRepository.findByOrderIdAndSeller(orderId, sellerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When: 주문 상태 변경 실행
+            OrderStatusUpdateResponse response = orderService.updateOrderStatus(orderId, statusUpdateRequest, userDetails);
+
+            // Then: 결과 검증
+            assertThat(response).isNotNull();                                    // 응답이 있는지 확인
+            assertThat(response.getOrderId()).isEqualTo(100L);                  // 주문 ID가 맞는지 확인
+            assertThat(response.getStatus()).isEqualTo(OrderStatus.SHIPPED);    // 상태가 변경되었는지 확인
+            assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.SHIPPED);   // 실제 주문 객체도 변경되었는지 확인
+
+            // Mock 메서드가 올바르게 호출되었는지 검증
+            verify(userRepository).findByLoginId("testuser");
+            verify(orderRepository).findByOrderIdAndSeller(orderId, sellerUser);
+        }
+
+        @Test
+        @DisplayName("성공: 주문됨 → 취소로 변경")
+        void updateOrderStatus_Success_OrderedToCancelled() {
+            // Given: 주문을 취소로 변경하려는 상황
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.CANCELLED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(sellerUser));
+            given(orderRepository.findByOrderIdAndSeller(orderId, sellerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When: 주문 상태 변경 실행
+            OrderStatusUpdateResponse response = orderService.updateOrderStatus(orderId, statusUpdateRequest, userDetails);
+
+            // Then: 결과 검증
+            assertThat(response.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+        }
+
+        @Test
+        @DisplayName("성공: 배송중 → 배송완료로 변경")
+        void updateOrderStatus_Success_ShippedToDelivered() {
+            // Given: 배송중인 주문을 배송완료로 변경
+            testOrder.updateStatus(OrderStatus.SHIPPED);  // 먼저 배송중 상태로 만들기
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.DELIVERED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(sellerUser));
+            given(orderRepository.findByOrderIdAndSeller(orderId, sellerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When
+            OrderStatusUpdateResponse response = orderService.updateOrderStatus(orderId, statusUpdateRequest, userDetails);
+
+            // Then
+            assertThat(response.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+            assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+        }
+
+        @Test
+        @DisplayName("실패: 판매자 권한이 없는 경우")
+        void updateOrderStatus_Fail_NotSeller() {
+            // Given: 일반 사용자가 판매자 권한 필요한 작업을 시도
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.SHIPPED);
+
+            // 일반 사용자로 로그인
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(buyerUser));
+
+            // When & Then: 권한 오류가 발생해야 함
+            assertThatThrownBy(() -> orderService.updateOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.ORDER_FORBIDDEN.getMessage());
+
+            verify(userRepository).findByLoginId("testuser");
+        }
+
+        @Test
+        @DisplayName("실패: 주문을 찾을 수 없는 경우")
+        void updateOrderStatus_Fail_OrderNotFound() {
+            // Given: 존재하지 않는 주문 ID
+            Long orderId = 999L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.SHIPPED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(sellerUser));
+            // 주문을 찾지 못하는 상황
+            given(orderRepository.findByOrderIdAndSeller(orderId, sellerUser))
+                    .willReturn(Optional.empty());
+
+            // When & Then: 주문 없음 오류가 발생해야 함
+            assertThatThrownBy(() -> orderService.updateOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 상태 변경 (주문됨 → 배송완료)")
+        void updateOrderStatus_Fail_InvalidStatusChange() {
+            // Given: 주문됨 상태에서 바로 배송완료로 변경 시도 (잘못된 순서)
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.DELIVERED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(sellerUser));
+            given(orderRepository.findByOrderIdAndSeller(orderId, sellerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When & Then: 잘못된 상태 변경 오류가 발생해야 함
+            assertThatThrownBy(() -> orderService.updateOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 완료된 주문 상태 변경 시도")
+        void updateOrderStatus_Fail_AlreadyCompletedOrder() {
+            // Given: 이미 배송완료된 주문을 다시 변경 시도
+            testOrder.updateStatus(OrderStatus.DELIVERED);  // 배송완료 상태로 설정
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.SHIPPED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(sellerUser));
+            given(orderRepository.findByOrderIdAndSeller(orderId, sellerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When & Then: 완료된 주문은 변경할 수 없음
+            assertThatThrownBy(() -> orderService.updateOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+        }
+    }
+
+    /**
+     * 🛒 사용자 주문 상태 변경 테스트
+     * 일반 사용자가 자신의 주문 상태를 변경하는 테스트 (취소, 반품)
+     */
+    @Nested
+    @DisplayName("사용자 주문 상태 변경")
+    class UserOrderStatusUpdate {
+
+        @Test
+        @DisplayName("성공: 주문 취소 (주문됨 → 취소)")
+        void updateUserOrderStatus_Success_OrderCancel() {
+            // Given: 주문된 상품을 취소하려는 상황
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.CANCELLED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(buyerUser));
+            given(orderRepository.findByOrderIdAndUser(orderId, buyerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When: 주문 취소 실행
+            OrderStatusUpdateResponse response = orderService.updateUserOrderStatus(orderId, statusUpdateRequest, userDetails);
+
+            // Then: 취소 성공 검증
+            assertThat(response).isNotNull();
+            assertThat(response.getOrderId()).isEqualTo(100L);
+            assertThat(response.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+            assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+
+            verify(userRepository).findByLoginId("testuser");
+            verify(orderRepository).findByOrderIdAndUser(orderId, buyerUser);
+        }
+
+        @Test
+        @DisplayName("성공: 상품 반품 (배송완료 → 반품)")
+        void updateUserOrderStatus_Success_OrderReturn() {
+            // Given: 배송완료된 상품을 반품하려는 상황
+            testOrder.updateStatus(OrderStatus.DELIVERED);  // 배송완료 상태로 설정
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.RETURNED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(buyerUser));
+            given(orderRepository.findByOrderIdAndUser(orderId, buyerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When: 반품 신청 실행
+            OrderStatusUpdateResponse response = orderService.updateUserOrderStatus(orderId, statusUpdateRequest, userDetails);
+
+            // Then: 반품 신청 성공 검증
+            assertThat(response.getStatus()).isEqualTo(OrderStatus.RETURNED);
+            assertThat(testOrder.getStatus()).isEqualTo(OrderStatus.RETURNED);
+        }
+
+        @Test
+        @DisplayName("실패: 다른 사용자의 주문 변경 시도")
+        void updateUserOrderStatus_Fail_NotMyOrder() {
+            // Given: 다른 사용자의 주문을 변경하려는 시도
+            User anotherUser = new User("another", "password", "another@test.com", UserRole.USER);
+            ReflectionTestUtils.setField(anotherUser, "id", 3L);
+
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.CANCELLED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(anotherUser));
+            // 다른 사용자로는 주문을 찾을 수 없음
+            given(orderRepository.findByOrderIdAndUser(orderId, anotherUser))
+                    .willReturn(Optional.empty());
+
+            // When & Then: 주문 없음 오류 발생
+            assertThatThrownBy(() -> orderService.updateUserOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.ORDER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 상태에서 취소 시도 (배송중 → 취소)")
+        void updateUserOrderStatus_Fail_InvalidCancelStatus() {
+            // Given: 이미 배송중인 상품을 취소하려는 시도
+            testOrder.updateStatus(OrderStatus.SHIPPED);  // 배송중 상태로 설정
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.CANCELLED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(buyerUser));
+            given(orderRepository.findByOrderIdAndUser(orderId, buyerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When & Then: 배송중인 상품은 취소할 수 없음
+            assertThatThrownBy(() -> orderService.updateUserOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 상태에서 반품 시도 (주문됨 → 반품)")
+        void updateUserOrderStatus_Fail_InvalidReturnStatus() {
+            // Given: 아직 배송되지 않은 상품을 반품하려는 시도
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.RETURNED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(buyerUser));
+            given(orderRepository.findByOrderIdAndUser(orderId, buyerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When & Then: 배송완료되지 않은 상품은 반품할 수 없음
+            assertThatThrownBy(() -> orderService.updateUserOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 사용자가 판매자 전용 상태로 변경 시도")
+        void updateUserOrderStatus_Fail_UserTriesToSetSellerStatus() {
+            // Given: 사용자가 배송중 상태로 변경 시도 (판매자만 가능)
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.SHIPPED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(buyerUser));
+            given(orderRepository.findByOrderIdAndUser(orderId, buyerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When & Then: 사용자는 배송 상태를 변경할 수 없음
+            assertThatThrownBy(() -> orderService.updateUserOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 취소된 주문에 대한 추가 변경")
+        void updateUserOrderStatus_Fail_AlreadyCancelledOrder() {
+            // Given: 이미 취소된 주문을 또 변경하려는 시도
+            testOrder.updateStatus(OrderStatus.CANCELLED);  // 취소 상태로 설정
+            Long orderId = 100L;
+            statusUpdateRequest = createStatusUpdateRequest(OrderStatus.RETURNED);
+
+            given(userRepository.findByLoginId("testuser")).willReturn(Optional.of(buyerUser));
+            given(orderRepository.findByOrderIdAndUser(orderId, buyerUser))
+                    .willReturn(Optional.of(testOrder));
+
+            // When & Then: 취소된 주문은 더 이상 변경할 수 없음
+            assertThatThrownBy(() -> orderService.updateUserOrderStatus(orderId, statusUpdateRequest, userDetails))
+                    .isInstanceOf(OrderException.class)
+                    .hasMessage(ErrorCode.INVALID_ORDER_STATUS.getMessage());
+        }
+    }
+
+    /**
+     * 🛠️ 테스트 헬퍼 메서드
+     * 테스트에서 반복적으로 사용되는 객체 생성을 돕는 메서드
+     */
+    private OrderStatusUpdateRequest createStatusUpdateRequest(OrderStatus status) {
+        OrderStatusUpdateRequest request = new OrderStatusUpdateRequest();
+        // ReflectionTestUtils를 사용해 private 필드에 값 설정
+        ReflectionTestUtils.setField(request, "status", status);
+        return request;
+    }
+}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
**사용자 주문 상태 변경 API 구현 및 테스트 코드 추가**

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore

---

## 🎯 What & Why

### 무엇을 했나요?
- 사용자가 자신의 주문 상태를 변경할 수 있는 API 구현
- 주문 취소(ORDERED → CANCELLED) 및 반품 신청(DELIVERED → RETURNED) 기능
- 포괄적인 단위 테스트 코드 작성 (`OrderStatusTest`)
- 사용자 권한별 상태 변경 검증 로직 구현

### 왜 필요했나요?
- **고객 편의성 향상**: 사용자가 직접 주문 취소 및 반품을 신청할 수 있어 고객 만족도 증대
- **운영 효율성**: 고객센터 문의 없이도 자동화된 주문 상태 변경으로 운영 부담 감소
- **비즈니스 요구사항**: 일반적인 이커머스 플랫폼의 필수 기능으로 사용자 경험 완성도 제고
- **데이터 무결성**: 잘못된 상태 변경을 방지하는 검증 로직으로 시스템 안정성 확보

---

## 🔧 How (구현 방법)

### 주요 변경사항
- **Controller Layer**: `OrderUserController.updateUserOrderStatus()` 메서드 추가
- **Service Layer**: `OrderService.updateUserOrderStatus()` 및 `validateUserStatusUpdate()` 메서드 구현  
- **Business Logic**: 사용자별 주문 상태 변경 권한 제한 로직
  - 일반 사용자: `ORDERED` → `CANCELLED`, `DELIVERED` → `RETURNED`만 허용
  - 판매자 전용 상태(`SHIPPED`, `DELIVERED`) 변경 방지
- **Test Code**: 성공/실패 시나리오를 모두 포함한 26개 테스트 케이스 작성

### 기술적 접근
- **권한 기반 접근 제어**: Spring Security `UserDetails`를 활용한 사용자 인증
- **도메인 주도 설계**: `Order.updateStatus()` 도메인 메서드를 통한 상태 변경
- **예외 처리**: `OrderException`과 `ErrorCode`를 활용한 일관된 에러 응답
- **트랜잭션 관리**: `@Transactional` 어노테이션으로 데이터 일관성 보장
- **입력 검증**: `@Valid`와 `@NotNull`을 통한 요청 데이터 유효성 검사

---

## 🧪 Testing

### 테스트 방법
```bash
# 단위 테스트 실행
./gradlew test --tests "*OrderStatusTest*"

# 전체 주문 관련 테스트 실행  
./gradlew test --tests "*order*"
```

### 확인 사항
- [x] **기능 정상 동작 확인**
  - 주문 취소 API (`ORDERED` → `CANCELLED`) 정상 동작
  - 반품 신청 API (`DELIVERED` → `RETURNED`) 정상 동작
- [x] **기존 기능 영향 없음**
  - 판매자 주문 상태 변경 기능 정상 동작 유지
  - 기존 주문 조회 API들 정상 동작 확인
- [x] **예외 케이스 테스트 완료**
  - 권한 없는 사용자의 접근 차단
  - 잘못된 상태 변경 시도 방지
  - 다른 사용자 주문 변경 시도 차단
  - 이미 완료/취소된 주문의 추가 변경 방지

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #OR-407
- 지라 백로그: [OR-407] 사용자 주문 상태 변경 API 구현
- API 명세서: `POST /api/users/orders/{orderId}/status`

---

## 💬 Additional Notes

### 🔍 리뷰 포인트
1. **비즈니스 로직 검증**: `validateUserStatusUpdate()` 메서드의 상태 전이 규칙이 올바른지 확인
2. **보안 검토**: 사용자가 자신의 주문만 변경할 수 있는지 권한 체크 로직 검토
3. **테스트 커버리지**: 26개 테스트 케이스가 모든 엣지 케이스를 다루는지 확인
4. **에러 메시지**: 사용자 친화적인 오류 메시지 제공 여부

### ⚠️ 주의사항
- 배송 시작 후(`SHIPPED`) 주문 취소는 불가능하도록 설계됨
- 반품은 배송완료(`DELIVERED`) 상태에서만 가능
- 이미 취소/반품된 주문은 추가 상태 변경 불가

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료 (26개 테스트 케이스 Pass)
- [x] 불필요한 로그 제거
- [x] API 문서 업데이트
- [x] 예외 처리 완료
- [x] 트랜잭션 처리 확인