### PR TITLE
MYCE-96 : feat/feed - feedDelete 피드삭제 API 구현

### DIFF
--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedDeleteService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedDeleteService.java
@@ -1,0 +1,61 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.feed.application.exception.FeedAccessDeniedException;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedDeleteService {
+
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 본인 피드 소프트 삭제
+     *
+     * @param feedId 삭제할 피드 ID
+     * @param userDetails 인증 사용자 정보 (loginId 사용)
+     */
+    @Transactional
+    public void deleteFeed(Long feedId, UserDetails userDetails) {
+        log.info("피드 삭제 요청 - feedId: {}", feedId);
+
+        // 인증 사용자 조회
+        String loginId = userDetails != null ? userDetails.getUsername() : null;
+        if (loginId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        }
+        User requester = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        // 피드 조회
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedNotFoundException(feedId));
+
+        // 이미 삭제된 경우 비노출 정책(404) 처리
+        if (feed.isDeleted()) {
+            throw new FeedNotFoundException(feedId);
+        }
+
+        // 소유권 확인
+        if (feed.getUser() == null || !feed.getUser().getId().equals(requester.getId())) {
+            throw new FeedAccessDeniedException("본인의 피드만 삭제할 수 있습니다.");
+        }
+
+        // 소프트 삭제
+        feed.softDelete();
+        log.info("피드 삭제 완료 - feedId: {}", feedId);
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedDeleteController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedDeleteController.java
@@ -1,0 +1,35 @@
+package com.cMall.feedShop.feed.presentation;
+
+import com.cMall.feedShop.common.aop.ApiResponseFormat;
+import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.feed.application.service.FeedDeleteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/feeds")
+@RequiredArgsConstructor
+public class FeedDeleteController {
+
+    private final FeedDeleteService feedDeleteService;
+
+    /**
+     * 피드 삭제 (FD-804)
+     */
+    @DeleteMapping("/{feedId}")
+    @ApiResponseFormat(message = "요청하신 피드를 성공적으로 삭제했습니다.", status = 200)
+    public ResponseEntity<ApiResponse<Void>> deleteFeed(@PathVariable Long feedId,
+                                                        @AuthenticationPrincipal UserDetails userDetails) {
+        log.info("피드 삭제 요청 - feedId: {}", feedId);
+        feedDeleteService.deleteFeed(feedId, userDetails);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/test/java/com/cMall/feedShop/feed/application/service/FeedDeleteServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/feed/application/service/FeedDeleteServiceTest.java
@@ -1,0 +1,155 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.feed.application.exception.FeedAccessDeniedException;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.order.domain.model.OrderItem;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedDeleteServiceTest {
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserDetails userDetails;
+
+    @InjectMocks
+    private FeedDeleteService feedDeleteService;
+
+    private User owner;
+    private User anotherUser;
+    private Feed feed;
+
+    @BeforeEach
+    void setUp() {
+        owner = new User(1L, "owner_login", "password", "owner@test.com", UserRole.USER);
+        anotherUser = new User(2L, "another_login", "password", "another@test.com", UserRole.USER);
+
+        OrderItem orderItem = OrderItem.builder()
+                .quantity(1)
+                .totalPrice(java.math.BigDecimal.valueOf(10000))
+                .finalPrice(java.math.BigDecimal.valueOf(9000))
+                .build();
+
+        feed = Feed.builder()
+                .user(owner)
+                .orderItem(orderItem)
+                .title("제목")
+                .content("내용")
+                .instagramId("insta")
+                .build();
+    }
+
+    @Test
+    @DisplayName("본인 피드 삭제 성공")
+    void deleteFeed_Success() {
+        // given
+        Long feedId = 10L;
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+
+        // when
+        feedDeleteService.deleteFeed(feedId, userDetails);
+
+        // then
+        assertThat(feed.isDeleted()).isTrue();
+        verify(feedRepository, times(1)).findById(feedId);
+        verify(userRepository, times(1)).findByLoginId("owner_login");
+    }
+
+    @Test
+    @DisplayName("비소유자 삭제 시 403 예외")
+    void deleteFeed_Forbidden_NotOwner() {
+        // given
+        Long feedId = 11L;
+        when(userDetails.getUsername()).thenReturn("another_login");
+        when(userRepository.findByLoginId("another_login")).thenReturn(Optional.of(anotherUser));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+
+        // when & then
+        assertThatThrownBy(() -> feedDeleteService.deleteFeed(feedId, userDetails))
+                .isInstanceOf(FeedAccessDeniedException.class)
+                .hasMessageContaining("본인의 피드만 삭제할 수 있습니다");
+    }
+
+    @Test
+    @DisplayName("피드 미존재 시 404 예외")
+    void deleteFeed_NotFound() {
+        // given
+        Long feedId = 12L;
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedDeleteService.deleteFeed(feedId, userDetails))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 피드 삭제 시 404 예외")
+    void deleteFeed_AlreadyDeleted() {
+        // given
+        Long feedId = 13L;
+        feed.softDelete();
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+
+        // when & then
+        assertThatThrownBy(() -> feedDeleteService.deleteFeed(feedId, userDetails))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("미인증(credential 없음) 시 401 예외")
+    void deleteFeed_Unauthorized_WhenNoUserDetails() {
+        // given
+        Long feedId = 14L;
+
+        // when & then
+        assertThatThrownBy(() -> feedDeleteService.deleteFeed(feedId, null))
+                .isInstanceOf(BusinessException.class)
+                .hasMessageContaining("인증 정보가 없습니다.")
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED));
+    }
+
+    @Test
+    @DisplayName("사용자 조회 실패 시 USER_NOT_FOUND 예외")
+    void deleteFeed_UserNotFound() {
+        // given
+        Long feedId = 15L;
+        when(userDetails.getUsername()).thenReturn("unknown_login");
+        when(userRepository.findByLoginId("unknown_login")).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedDeleteService.deleteFeed(feedId, userDetails))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
본인 피드 삭제 API(Soft Delete) 구현 및 컨트롤러 분리, 단위 테스트 추가

**Type**
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- 본인 피드 삭제 API 구현 (**Soft Delete**: `deletedAt` 세팅)
- 상세/삭제 컨트롤러 분리 (조회 전용, 삭제 전용)
- 서비스 단위 테스트 추가 (성공/권한/미존재/이미삭제/미인증/사용자없음)

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
- 작성자가 본인 컨텐츠를 안전하게 **비노출(삭제)** 할 수 있어야 함
- 컨트롤러 책임 분리로 유지보수성 및 가독성 향상
- 예외 처리를 전역/일관 포맷으로 제공해 클라이언트 처리 단순화

---

## 🔧 How (구현 방법)
### 주요 변경사항
- **`feed/application/service/FeedDeleteService.java`**  
  소유권/상태 검증 후 `softDelete()` 구현
- **`feed/presentation/FeedDeleteController.java`**  
  `DELETE /api/feeds/{feedId}` 엔드포인트 신설
- **`feed/presentation/FeedDetailController.java`**  
  조회 전용으로 정리 (`try/catch` 제거, AOP 적용)
- 전역 응답 AOP(`@ApiResponseFormat`)로 메시지/HTTP 상태 일관 적용

### 기술적 접근
1. 인증 사용자(`loginId`)로 `User` 조회  
2. 피드 조회  
3. 삭제 여부/소유권 검증  
4. `softDelete()` 실행


#### 예외 매핑
- **401**: 인증 없음 (`BusinessException.UNAUTHORIZED`)
- **403**: 비소유자 (`FeedAccessDeniedException`)
- **404**: 미존재/이미 삭제 (`FeedNotFoundException`)

#### 응답 형식
- `ApiResponse.success(null)` (AOP로 메시지/상태 적용)

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
- 작성자 본인 삭제 성공 → `200`
- 비소유자 삭제 요청 → `403`
- 존재하지 않는 피드 → `404`
- 이미 삭제된 피드 → `404`
- 미인증 사용자 → `401`
- 사용자 조회 실패 → `404`

```bash
./gradlew test --tests FeedDeleteServiceTest
### 확인 사항
- [X] 기능 정상 동작 확인
- [X] 기존 기능 영향 없음
- [X] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #486 
- 지라 백로그: MYCE-96
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
- 보안 정책(`DELETE /api/feeds/` 인증 필수) 확인/적용 필요 시 별도 PR에서 보강 가능

---

## ✅ Checklist
- [X] 코드 리뷰 준비 완료
- [X] 테스트 완료
- [X] 불필요한 로그 제거
