### PR TITLE
MYCE-95 : feat/feed - 본인 피드 수정 API 구현

### DIFF
--- a/src/main/java/com/cMall/feedShop/feed/application/dto/request/FeedUpdateRequestDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/request/FeedUpdateRequestDto.java
@@ -1,0 +1,35 @@
+package com.cMall.feedShop.feed.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FeedUpdateRequestDto {
+
+    /**
+     * 제목: 필수, 최대 100자
+     */
+    @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 100, message = "제목은 최대 100자까지 가능합니다.")
+    private String title;
+
+    /**
+     * 내용: 선택, 최대 2000자
+     */
+    @Size(max = 2000, message = "내용은 최대 2000자까지 가능합니다.")
+    private String content;
+
+    /**
+     * 인스타그램 ID: 선택, 영문/숫자/밑줄/점, 1~30자
+     */
+    @Pattern(regexp = "^[a-zA-Z0-9._]{0,30}$", message = "인스타그램 ID는 영문/숫자/밑줄/점으로 30자 이내여야 합니다.")
+    private String instagramId;
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/dto/request/FeedUpdateRequestDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/request/FeedUpdateRequestDto.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -28,8 +30,16 @@ public class FeedUpdateRequestDto {
     private String content;
 
     /**
-     * 인스타그램 ID: 선택, 영문/숫자/밑줄/점, 1~30자
+     * 인스타그램 ID: 선택, 영문/숫자/밑줄/점, 0~30자
      */
     @Pattern(regexp = "^[a-zA-Z0-9._]{0,30}$", message = "인스타그램 ID는 영문/숫자/밑줄/점으로 30자 이내여야 합니다.")
     private String instagramId;
+
+    /**
+     * 해시태그 목록: 선택, 최대 20개, 각 태그는 영문/숫자/밑줄/한글로 구성(공백 제외), 최대 30자
+     */
+    @Size(max = 20, message = "해시태그는 최대 20개까지 가능합니다.")
+    private List<@Size(max = 30, message = "태그는 최대 30자까지 가능합니다.")
+                 @Pattern(regexp = "^[A-Za-z0-9_가-힣]+$", message = "태그는 영문/숫자/밑줄/한글만 사용할 수 있습니다.")
+                 String> hashtags;
 }

--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedUpdateService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedUpdateService.java
@@ -1,0 +1,89 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.feed.application.dto.request.FeedUpdateRequestDto;
+import com.cMall.feedShop.feed.application.dto.response.FeedDetailResponseDto;
+import com.cMall.feedShop.feed.application.exception.FeedAccessDeniedException;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedUpdateService {
+
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+    private final FeedMapper feedMapper;
+
+    /**
+     * 본인 피드 수정(제목/내용/인스타그램/해시태그)
+     */
+    @Transactional
+    public FeedDetailResponseDto updateFeed(Long feedId, FeedUpdateRequestDto requestDto, UserDetails userDetails) {
+        log.info("피드 수정 요청 - feedId: {}", feedId);
+
+        String loginId = userDetails != null ? userDetails.getUsername() : null;
+        if (loginId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        }
+        User requester = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        // 상세 조회로 연관 로딩(해시태그 등)
+        Feed feed = feedRepository.findDetailById(feedId)
+                .orElseThrow(() -> new FeedNotFoundException(feedId));
+
+        if (feed.isDeleted()) {
+            throw new FeedNotFoundException(feedId);
+        }
+        if (feed.getUser() == null || !feed.getUser().getId().equals(requester.getId())) {
+            throw new FeedAccessDeniedException("본인의 피드만 수정할 수 있습니다.");
+        }
+
+        // 본문 데이터 수정
+        feed.updateContent(requestDto.getTitle(), requestDto.getContent(), requestDto.getInstagramId());
+
+        // 해시태그 업데이트: null이면 유지, 빈 리스트면 모두 제거, 값 있으면 재구성
+        if (requestDto.getHashtags() != null) {
+            // 정규화 & 중복 제거(입력 순서 유지)
+            Set<String> normalized = requestDto.getHashtags().stream()
+                    .map(this::normalizeTag)
+                    .filter(tag -> !tag.isEmpty())
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+            // 기존 제거
+            feed.getHashtags().clear();
+            // 재추가
+            if (!normalized.isEmpty()) {
+                feed.addHashtags(List.copyOf(normalized));
+            }
+        }
+
+        // 영속 컨텍스트에 의해 자동 반영됨
+        return feedMapper.toFeedDetailResponseDto(feed);
+    }
+
+    private String normalizeTag(String raw) {
+        if (raw == null) return "";
+        String trimmed = raw.trim();
+        if (trimmed.startsWith("#")) {
+            trimmed = trimmed.substring(1);
+        }
+        return trimmed.trim();
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedUpdateController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedUpdateController.java
@@ -1,0 +1,40 @@
+package com.cMall.feedShop.feed.presentation;
+
+import com.cMall.feedShop.common.aop.ApiResponseFormat;
+import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.feed.application.dto.request.FeedUpdateRequestDto;
+import com.cMall.feedShop.feed.application.dto.response.FeedDetailResponseDto;
+import com.cMall.feedShop.feed.application.service.FeedUpdateService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/feeds")
+@RequiredArgsConstructor
+public class FeedUpdateController {
+
+    private final FeedUpdateService feedUpdateService;
+
+    /**
+     * 피드 수정 (FD-805)
+     */
+    @PutMapping("/{feedId}")
+    @ApiResponseFormat(message = "피드를 성공적으로 수정했습니다.", status = 200)
+    public ResponseEntity<ApiResponse<FeedDetailResponseDto>> updateFeed(@PathVariable Long feedId,
+                                                                         @Valid @RequestBody FeedUpdateRequestDto request,
+                                                                         @AuthenticationPrincipal UserDetails userDetails) {
+        log.info("피드 수정 요청 - feedId: {}", feedId);
+        FeedDetailResponseDto result = feedUpdateService.updateFeed(feedId, request, userDetails);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/test/java/com/cMall/feedShop/feed/application/service/FeedUpdateServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/feed/application/service/FeedUpdateServiceTest.java
@@ -1,0 +1,217 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.feed.application.dto.request.FeedUpdateRequestDto;
+import com.cMall.feedShop.feed.application.dto.response.FeedDetailResponseDto;
+import com.cMall.feedShop.feed.application.exception.FeedAccessDeniedException;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.FeedHashtag;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.order.domain.model.OrderItem;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedUpdateServiceTest {
+
+    @Mock private FeedRepository feedRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private FeedMapper feedMapper;
+    @Mock private UserDetails userDetails;
+
+    @InjectMocks private FeedUpdateService feedUpdateService;
+
+    private User owner;
+    private User anotherUser;
+    private Feed feed;
+    private FeedDetailResponseDto responseDto;
+
+    @BeforeEach
+    void setUp() {
+        owner = new User(1L, "owner_login", "password", "owner@test.com", UserRole.USER);
+        anotherUser = new User(2L, "another_login", "password", "another@test.com", UserRole.USER);
+
+        OrderItem orderItem = OrderItem.builder()
+                .quantity(1)
+                .totalPrice(java.math.BigDecimal.valueOf(10000))
+                .finalPrice(java.math.BigDecimal.valueOf(9000))
+                .build();
+
+        feed = Feed.builder()
+                .user(owner)
+                .orderItem(orderItem)
+                .title("old title")
+                .content("old content")
+                .instagramId("old_insta")
+                .build();
+        // 기존 해시태그 2개
+        feed.addHashtags(List.of("old1", "old2"));
+
+        responseDto = FeedDetailResponseDto.builder()
+                .feedId(100L)
+                .title("new title")
+                .content("new content")
+                .instagramId("new.insta")
+                .build();
+    }
+
+    @Test
+    @DisplayName("본인 피드 수정 성공 - 본문/해시태그 재구성")
+    void updateFeed_Success() {
+        // given
+        Long feedId = 100L;
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(feed));
+
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder()
+                .title("new title")
+                .content("new content")
+                .instagramId("new.insta")
+                .hashtags(List.of("#tag1", "tag2", "tag1", " "))
+                .build();
+
+        when(feedMapper.toFeedDetailResponseDto(feed)).thenReturn(responseDto);
+
+        // when
+        FeedDetailResponseDto result = feedUpdateService.updateFeed(feedId, dto, userDetails);
+
+        // then 본문 값 변경 확인
+        assertThat(feed.getTitle()).isEqualTo("new title");
+        assertThat(feed.getContent()).isEqualTo("new content");
+        assertThat(feed.getInstagramId()).isEqualTo("new.insta");
+        // 해시태그: # 제거/공백 필터/중복 제거 → [tag1, tag2]
+        List<String> tags = feed.getHashtags().stream().map(FeedHashtag::getTag).collect(Collectors.toList());
+        assertThat(tags).containsExactly("tag1", "tag2");
+
+        assertThat(result).isSameAs(responseDto);
+    }
+
+    @Test
+    @DisplayName("해시태그 null 시 유지")
+    void updateFeed_KeepHashtags_WhenNull() {
+        Long feedId = 101L;
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(feed));
+
+        List<String> before = feed.getHashtags().stream().map(FeedHashtag::getTag).collect(Collectors.toList());
+
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder()
+                .title("t")
+                .content("c")
+                .instagramId("i")
+                .hashtags(null)
+                .build();
+        when(feedMapper.toFeedDetailResponseDto(feed)).thenReturn(responseDto);
+
+        feedUpdateService.updateFeed(feedId, dto, userDetails);
+
+        List<String> after = feed.getHashtags().stream().map(FeedHashtag::getTag).collect(Collectors.toList());
+        assertThat(after).isEqualTo(before);
+    }
+
+    @Test
+    @DisplayName("해시태그 빈 리스트 시 모두 제거")
+    void updateFeed_ClearHashtags_WhenEmpty() {
+        Long feedId = 102L;
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(feed));
+
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder()
+                .title("t")
+                .content("c")
+                .instagramId("i")
+                .hashtags(List.of())
+                .build();
+        when(feedMapper.toFeedDetailResponseDto(feed)).thenReturn(responseDto);
+
+        feedUpdateService.updateFeed(feedId, dto, userDetails);
+        assertThat(feed.getHashtags()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("비소유자 수정 시 403")
+    void updateFeed_Forbidden_NotOwner() {
+        Long feedId = 103L;
+        when(userDetails.getUsername()).thenReturn("another_login");
+        when(userRepository.findByLoginId("another_login")).thenReturn(Optional.of(anotherUser));
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(feed));
+
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder().title("t").build();
+        assertThatThrownBy(() -> feedUpdateService.updateFeed(feedId, dto, userDetails))
+                .isInstanceOf(FeedAccessDeniedException.class)
+                .hasMessageContaining("본인의 피드만 수정할 수 있습니다");
+    }
+
+    @Test
+    @DisplayName("피드 미존재 404")
+    void updateFeed_NotFound() {
+        Long feedId = 104L;
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.empty());
+
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder().title("t").build();
+        assertThatThrownBy(() -> feedUpdateService.updateFeed(feedId, dto, userDetails))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이미 삭제된 피드 404")
+    void updateFeed_Deleted_NotFound() {
+        Long feedId = 105L;
+        feed.softDelete();
+        when(userDetails.getUsername()).thenReturn("owner_login");
+        when(userRepository.findByLoginId("owner_login")).thenReturn(Optional.of(owner));
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(feed));
+
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder().title("t").build();
+        assertThatThrownBy(() -> feedUpdateService.updateFeed(feedId, dto, userDetails))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("미인증 401")
+    void updateFeed_Unauthorized() {
+        Long feedId = 106L;
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder().title("t").build();
+        assertThatThrownBy(() -> feedUpdateService.updateFeed(feedId, dto, null))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED));
+    }
+
+    @Test
+    @DisplayName("사용자 조회 실패 USER_NOT_FOUND")
+    void updateFeed_UserNotFound() {
+        Long feedId = 107L;
+        when(userDetails.getUsername()).thenReturn("unknown");
+        when(userRepository.findByLoginId("unknown")).thenReturn(Optional.empty());
+
+        FeedUpdateRequestDto dto = FeedUpdateRequestDto.builder().title("t").build();
+        assertThatThrownBy(() -> feedUpdateService.updateFeed(feedId, dto, userDetails))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
본인 피드 **수정 API**(제목/내용/인스타그램/해시태그) 구현

**Type**
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- 피드 수정 API 구현 (제목, 내용, 인스타그램 ID, 해시태그)
- 요청 DTO 검증 추가 (길이/패턴)
- 수정 서비스 구현 (소유권/삭제/인증 검증 포함) 및 상세 DTO 반환
- 컨트롤러 분리 (수정 전용)
- 서비스 단위 테스트 추가 (성공/권한/미존재/삭제됨/미인증/사용자없음/해시태그 케이스)

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
- 작성자가 본인 컨텐츠를 최신화하고 해시태그를 관리할 수 있어야 함
- 컨트롤러 책임 분리로 유지보수성과 가독성 향상
- 전역 예외/응답 포맷 적용으로 일관된 API 사용 경험 제공

---

## 🔧 How (구현 방법)
### 주요 변경사항
- **`feed/application/dto/request/FeedUpdateRequestDto.java`**
  - `title`(<=100, 필수), `content`(<=2000)
  - `instagramId`(패턴)
  - `hashtags`(최대 20개 / 각 30자, 패턴)
- **`feed/application/service/FeedUpdateService.java`**
  - 인증 사용자 조회 → 피드 상세 조회 → 삭제/소유권 검증 → 본문/해시태그 갱신 → 상세 DTO 반환
  - 해시태그 정책:
    - `null` → 기존 유지  
    - 빈 배열 → 모두 삭제  
    - 값 있음 → 정규화(#제거/공백 제거/중복 제거) 후 재구성
- **`feed/presentation/FeedUpdateController.java`**
  - `PUT /api/feeds/{feedId}` (전역 응답 AOP `@ApiResponseFormat` 적용)
- **테스트**: `feed/application/service/FeedUpdateServiceTest.java`
  - 성공 (본문/해시태그 재구성)
  - 해시태그 `null` 유지 / 빈 리스트 모두 제거
  - 비소유자 `403` / 미존재 `404` / 삭제됨 `404` / 미인증 `401` / 사용자없음 `404`

### 기술적 접근
- **인증**: `@AuthenticationPrincipal`로 `loginId` → User 조회
- **리소스 조회**: `findDetailById` 사용 (해시태그 등 연관 포함)
- **검증/예외**:
  - Bean Validation으로 DTO 유효성 검증
  - `BusinessException` / `FeedNotFoundException` / `FeedAccessDeniedException` → `GlobalExceptionHandler`로 표준 `ApiResponse` 변환
- **응답 포맷**: `@ApiResponseFormat`으로 성공 메시지/HTTP Status 일관 적용

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
- **단위 테스트**:
```bash
./gradlew test --tests FeedUpdateServiceTest```
- `PUT /api/feeds/{feedId}` 호출 시 요청 DTO 반영된 상세 DTO 반환
- `401` / `403` / `404` / `400` 케이스 정상 응답 확인

### 확인 사항
- [X] 기능 정상 동작 확인
- [X] 기존 기능 영향 없음
- [X] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #152
- 지라 백로그: MYCE-95
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
- 해시태그 수정은 본문 수정과 함께 처리하되, 향후 이미지/추가 메타 수정은 별도 API로 확장 가능
- 보안 정책 (수정 API 인증 필수) 확인 완료
---

## ✅ Checklist
- [X] 코드 리뷰 준비 완료
- [X] 테스트 완료
- [X] 불필요한 로그 제거
