### PR TITLE
MYCE-97 : feat/feed - feedLikes 피드 좋아요 API 구현

### DIFF
--- a/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeToggleResponseDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeToggleResponseDto.java
@@ -1,0 +1,15 @@
+package com.cMall.feedShop.feed.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LikeToggleResponseDto {
+    private boolean liked;
+    private int likeCount;
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeUserResponseDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeUserResponseDto.java
@@ -1,0 +1,44 @@
+package com.cMall.feedShop.feed.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 좋아요 사용자 정보 응답 DTO
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LikeUserResponseDto {
+    
+    /**
+     * 사용자 ID
+     */
+    private Long userId;
+    
+    /**
+     * 사용자 닉네임
+     */
+    private String nickname;
+    
+    /**
+     * 프로필 이미지 URL
+     */
+    private String profileImageUrl;
+    
+    /**
+     * 사용자 레벨
+     */
+    private Integer level;
+    
+    /**
+     * 좋아요 누른 시간
+     */
+    private LocalDateTime likedAt;
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedDetailService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedDetailService.java
@@ -4,8 +4,12 @@ import com.cMall.feedShop.feed.application.dto.response.FeedDetailResponseDto;
 import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
 import com.cMall.feedShop.feed.domain.Feed;
 import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.feed.domain.repository.FeedLikeRepository;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,16 +24,18 @@ public class FeedDetailService {
     
     private final FeedRepository feedRepository;
     private final FeedMapper feedMapper;
+    private final FeedLikeService feedLikeService;
     
     /**
      * 피드 상세 조회
      * 
      * @param feedId 피드 ID
+     * @param userDetails 사용자 정보 (선택적)
      * @return 피드 상세 정보
      * @throws FeedNotFoundException 피드를 찾을 수 없는 경우
      */
-    public FeedDetailResponseDto getFeedDetail(Long feedId) {
-        log.info("피드 상세 조회 요청 - feedId: {}", feedId);
+    public FeedDetailResponseDto getFeedDetail(Long feedId, UserDetails userDetails) {
+        log.info("피드 상세 조회 요청 - feedId: {}, userDetails: {}", feedId, userDetails != null ? "있음" : "없음");
         
         // 피드 조회 (삭제되지 않은 피드만)
         Feed feed = feedRepository.findDetailById(feedId)
@@ -41,9 +47,50 @@ public class FeedDetailService {
             throw new FeedNotFoundException(feedId, "삭제된 피드입니다.");
         }
         
-        log.info("피드 상세 조회 완료 - feedId: {}, 제목: {}", feedId, feed.getTitle());
+        // DTO 변환
+        FeedDetailResponseDto dto = feedMapper.toFeedDetailResponseDto(feed);
         
-        // DTO 변환 및 반환
-        return feedMapper.toFeedDetailResponseDto(feed);
+        // 사용자별 좋아요 상태 설정
+        boolean isLiked = feedLikeService.isLikedByUser(feedId, userDetails);
+        dto = FeedDetailResponseDto.builder()
+                .feedId(dto.getFeedId())
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .feedType(dto.getFeedType())
+                .instagramId(dto.getInstagramId())
+                .createdAt(dto.getCreatedAt())
+                .updatedAt(dto.getUpdatedAt())
+                .likeCount(dto.getLikeCount())
+                .commentCount(dto.getCommentCount())
+                .participantVoteCount(dto.getParticipantVoteCount())
+                .userId(dto.getUserId())
+                .userNickname(dto.getUserNickname())
+                .userProfileImg(dto.getUserProfileImg())
+                .userLevel(dto.getUserLevel())
+                .userGender(dto.getUserGender())
+                .userHeight(dto.getUserHeight())
+                .orderItemId(dto.getOrderItemId())
+                .productName(dto.getProductName())
+                .productSize(dto.getProductSize())
+                .productImageUrl(dto.getProductImageUrl())
+                .productId(dto.getProductId())
+                .eventId(dto.getEventId())
+                .eventTitle(dto.getEventTitle())
+                .eventDescription(dto.getEventDescription())
+                .eventStartDate(dto.getEventStartDate())
+                .eventEndDate(dto.getEventEndDate())
+                .hashtags(dto.getHashtags())
+                .images(dto.getImages())
+                .comments(dto.getComments())
+                .isLiked(isLiked)
+                .isVoted(dto.getIsVoted())
+                .canVote(dto.getCanVote())
+                .build();
+        
+        log.info("사용자별 좋아요 상태 설정 - feedId: {}, isLiked: {}", feedId, isLiked);
+        
+        log.info("피드 상세 조회 완료 - feedId: {}, 제목: {}, isLiked: {}", feedId, feed.getTitle(), dto.getIsLiked());
+        
+        return dto;
     }
 }

--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedLikeService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedLikeService.java
@@ -2,7 +2,9 @@ package com.cMall.feedShop.feed.application.service;
 
 import com.cMall.feedShop.common.exception.BusinessException;
 import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.common.dto.PaginatedResponse;
 import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.LikeUserResponseDto;
 import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
 import com.cMall.feedShop.feed.domain.Feed;
 import com.cMall.feedShop.feed.domain.FeedLike;
@@ -12,9 +14,15 @@ import com.cMall.feedShop.user.domain.model.User;
 import com.cMall.feedShop.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -67,5 +75,88 @@ public class FeedLikeService {
                 .liked(liked)
                 .likeCount(likeCount)
                 .build();
+    }
+
+    /**
+     * 좋아요 사용자 목록 조회
+     * - 피드 존재/삭제 여부 검증
+     * - 좋아요 누른 시간 기준 내림차순 정렬
+     * - 페이징 지원
+     */
+    @Transactional(readOnly = true)
+    public PaginatedResponse<LikeUserResponseDto> getLikedUsers(Long feedId, int page, int size) {
+        log.info("좋아요 사용자 목록 조회 요청 - feedId: {}, page: {}, size: {}", feedId, page, size);
+        
+        // 피드 존재 및 삭제 여부 검증
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedNotFoundException(feedId));
+        if (feed.isDeleted()) {
+            log.warn("삭제된 피드의 좋아요 사용자 목록 조회 시도 - feedId: {}", feedId);
+            throw new FeedNotFoundException(feedId);
+        }
+        
+        // 페이징 및 정렬 설정
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        
+        // 좋아요 사용자 목록 조회 (User 정보 포함)
+        Page<FeedLike> feedLikes = feedLikeRepository.findByFeedIdWithUser(feedId, pageRequest);
+        
+        // DTO 변환
+        List<LikeUserResponseDto> likeUsers = feedLikes.getContent().stream()
+                .map(this::toLikeUserResponseDto)
+                .collect(Collectors.toList());
+        
+        log.info("좋아요 사용자 목록 조회 완료 - feedId: {}, 총 {}명", feedId, feedLikes.getTotalElements());
+        
+        // PaginatedResponse 구성
+        return PaginatedResponse.<LikeUserResponseDto>builder()
+                .content(likeUsers)
+                .page(page)
+                .size(size)
+                .totalElements(feedLikes.getTotalElements())
+                .totalPages(feedLikes.getTotalPages())
+                .hasNext(feedLikes.hasNext())
+                .hasPrevious(feedLikes.hasPrevious())
+                .build();
+    }
+    
+    /**
+     * FeedLike 엔티티를 LikeUserResponseDto로 변환
+     */
+    private LikeUserResponseDto toLikeUserResponseDto(FeedLike feedLike) {
+        User user = feedLike.getUser();
+        return LikeUserResponseDto.builder()
+                .userId(user.getId())
+                .nickname(getUserNickname(user))
+                .profileImageUrl(getUserProfileImageUrl(user))
+                .level(getUserLevel(user))
+                .likedAt(feedLike.getCreatedAt())
+                .build();
+    }
+    
+    /**
+     * 사용자 닉네임 조회
+     */
+    private String getUserNickname(User user) {
+        if (user.getUserProfile() != null) {
+            return user.getUserProfile().getNickname();
+        }
+        return null;
+    }
+    
+    /**
+     * 사용자 프로필 이미지 URL 조회
+     */
+    private String getUserProfileImageUrl(User user) {
+        // TODO: 추후 UserProfile에 profileImageUrl 필드 추가 시 구현
+        return null;
+    }
+    
+    /**
+     * 사용자 레벨 조회
+     */
+    private Integer getUserLevel(User user) {
+        // TODO: 추후 UserProfile에 level 필드 추가 시 구현
+        return null;
     }
 }

--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedLikeService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedLikeService.java
@@ -1,0 +1,71 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.FeedLike;
+import com.cMall.feedShop.feed.domain.repository.FeedLikeRepository;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedLikeService {
+
+    private final FeedLikeRepository feedLikeRepository;
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 좋아요 토글
+     * - 없으면 생성(liked=true), 있으면 삭제(liked=false)
+     * - Feed.likeCount 증감
+     */
+    @Transactional
+    public LikeToggleResponseDto toggleLike(Long feedId, UserDetails userDetails) {
+        if (userDetails == null || userDetails.getUsername() == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증 정보가 없습니다.");
+        }
+        String loginId = userDetails.getUsername();
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedNotFoundException(feedId));
+        if (feed.isDeleted()) {
+            throw new FeedNotFoundException(feedId);
+        }
+
+        boolean exists = feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, user.getId());
+        boolean liked;
+        if (exists) {
+            // 취소
+            feedLikeRepository.deleteByFeed_IdAndUser_Id(feedId, user.getId());
+            feed.decrementLikeCount();
+            liked = false;
+        } else {
+            // 추가
+            feedLikeRepository.save(FeedLike.builder()
+                    .feed(feed)
+                    .user(user)
+                    .build());
+            feed.incrementLikeCount();
+            liked = true;
+        }
+
+        int likeCount = feed.getLikeCount() != null ? feed.getLikeCount() : 0;
+        return LikeToggleResponseDto.builder()
+                .liked(liked)
+                .likeCount(likeCount)
+                .build();
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedMapper.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedMapper.java
@@ -145,8 +145,8 @@ public class FeedMapper {
                 .eventTitle(getEventTitle(feed.getEvent()))
                 .hashtags(getHashtags(feed.getHashtags()))
                 .imageUrls(getImageUrls(feed.getImages()))
-                .isLiked(false) // 기본값, 실제로는 사용자별 상태 확인 필요
-                .isVoted(false) // 기본값, 실제로는 사용자별 상태 확인 필요
+                .isLiked(null) // 사용자별 상태는 서비스에서 설정
+                .isVoted(null) // 사용자별 상태는 서비스에서 설정
                 .build();
     }
     
@@ -187,8 +187,8 @@ public class FeedMapper {
                 .eventTitle(getEventTitle(feed.getEvent()))
                 .hashtags(getHashtags(feed.getHashtags()))
                 .imageUrls(getImageUrls(feed.getImages()))
-                .isLiked(false) // 기본값, 실제로는 사용자별 상태 확인 필요
-                .isVoted(false) // 기본값, 실제로는 사용자별 상태 확인 필요
+                .isLiked(null) // 사용자별 상태는 서비스에서 설정
+                .isVoted(null) // 사용자별 상태는 서비스에서 설정
                 .build();
     }
     
@@ -238,8 +238,8 @@ public class FeedMapper {
                 .hashtags(toFeedHashtagDtoList(feed.getHashtags()))
                 .images(toFeedImageDtoList(feed.getImages()))
                 .comments(toFeedCommentDtoList(feed.getComments()))
-                .isLiked(false) // 기본값, 실제로는 사용자별 상태 확인 필요
-                .isVoted(false) // 기본값, 실제로는 사용자별 상태 확인 필요
+                .isLiked(null) // 사용자별 상태는 서비스에서 설정
+                .isVoted(null) // 사용자별 상태는 서비스에서 설정
                 .canVote(feed.getFeedType() == com.cMall.feedShop.feed.domain.FeedType.EVENT) // 이벤트 피드만 투표 가능
                 .build();
     }

--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedReadService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedReadService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,17 +24,19 @@ public class FeedReadService {
     
     private final FeedRepository feedRepository;
     private final FeedMapper feedMapper;
+    private final FeedLikeService feedLikeService;
     
     /**
      * 피드 목록 조회 (필터링, 페이징, 정렬)
      * 
      * @param feedType 피드 타입 (DAILY, EVENT, RANKING, null=전체)
      * @param pageable 페이징 및 정렬 정보
+     * @param userDetails 사용자 정보 (선택적)
      * @return 피드 목록 페이지
      */
-    public Page<FeedListResponseDto> getFeeds(FeedType feedType, Pageable pageable) {
-        log.info("피드 목록 조회 - feedType: {}, page: {}, size: {}", 
-                feedType, pageable.getPageNumber(), pageable.getPageSize());
+    public Page<FeedListResponseDto> getFeeds(FeedType feedType, Pageable pageable, UserDetails userDetails) {
+        log.info("피드 목록 조회 - feedType: {}, page: {}, size: {}, userDetails: {}", 
+                feedType, pageable.getPageNumber(), pageable.getPageSize(), userDetails != null ? "있음" : "없음");
         
         Page<Feed> feedPage;
         
@@ -48,6 +51,35 @@ public class FeedReadService {
         // Feed 엔티티를 DTO로 변환
         Page<FeedListResponseDto> responsePage = feedPage.map(feedMapper::toFeedListResponseDto);
         
+        // 사용자별 좋아요 상태 설정
+        responsePage = responsePage.map(dto -> {
+            boolean isLiked = feedLikeService.isLikedByUser(dto.getFeedId(), userDetails);
+            return FeedListResponseDto.builder()
+                    .feedId(dto.getFeedId())
+                    .title(dto.getTitle())
+                    .content(dto.getContent())
+                    .feedType(dto.getFeedType())
+                    .instagramId(dto.getInstagramId())
+                    .createdAt(dto.getCreatedAt())
+                    .likeCount(dto.getLikeCount())
+                    .commentCount(dto.getCommentCount())
+                    .participantVoteCount(dto.getParticipantVoteCount())
+                    .userId(dto.getUserId())
+                    .userNickname(dto.getUserNickname())
+                    .userProfileImg(dto.getUserProfileImg())
+                    .userLevel(dto.getUserLevel())
+                    .orderItemId(dto.getOrderItemId())
+                    .productName(dto.getProductName())
+                    .productSize(dto.getProductSize())
+                    .eventId(dto.getEventId())
+                    .eventTitle(dto.getEventTitle())
+                    .hashtags(dto.getHashtags())
+                    .imageUrls(dto.getImageUrls())
+                    .isLiked(isLiked)
+                    .isVoted(dto.getIsVoted())
+                    .build();
+        });
+        
         log.info("피드 목록 조회 완료 - 총 {}개, 현재 페이지 {}개", 
                 responsePage.getTotalElements(), responsePage.getNumberOfElements());
         
@@ -59,14 +91,44 @@ public class FeedReadService {
      * 
      * @param feedType 피드 타입
      * @param pageable 페이징 및 정렬 정보
+     * @param userDetails 사용자 정보 (선택적)
      * @return 피드 목록 페이지
      */
-    public Page<FeedListResponseDto> getFeedsByType(FeedType feedType, Pageable pageable) {
-        log.info("피드 타입별 조회 - feedType: {}, page: {}, size: {}", 
-                feedType, pageable.getPageNumber(), pageable.getPageSize());
+    public Page<FeedListResponseDto> getFeedsByType(FeedType feedType, Pageable pageable, UserDetails userDetails) {
+        log.info("피드 타입별 조회 - feedType: {}, page: {}, size: {}, userDetails: {}", 
+                feedType, pageable.getPageNumber(), pageable.getPageSize(), userDetails != null ? "있음" : "없음");
         
         Page<Feed> feedPage = feedRepository.findByFeedType(feedType.name(), pageable);
         Page<FeedListResponseDto> responsePage = feedPage.map(feedMapper::toFeedListResponseDto);
+        
+        // 사용자별 좋아요 상태 설정
+        responsePage = responsePage.map(dto -> {
+            boolean isLiked = feedLikeService.isLikedByUser(dto.getFeedId(), userDetails);
+            return FeedListResponseDto.builder()
+                    .feedId(dto.getFeedId())
+                    .title(dto.getTitle())
+                    .content(dto.getContent())
+                    .feedType(dto.getFeedType())
+                    .instagramId(dto.getInstagramId())
+                    .createdAt(dto.getCreatedAt())
+                    .likeCount(dto.getLikeCount())
+                    .commentCount(dto.getCommentCount())
+                    .participantVoteCount(dto.getParticipantVoteCount())
+                    .userId(dto.getUserId())
+                    .userNickname(dto.getUserNickname())
+                    .userProfileImg(dto.getUserProfileImg())
+                    .userLevel(dto.getUserLevel())
+                    .orderItemId(dto.getOrderItemId())
+                    .productName(dto.getProductName())
+                    .productSize(dto.getProductSize())
+                    .eventId(dto.getEventId())
+                    .eventTitle(dto.getEventTitle())
+                    .hashtags(dto.getHashtags())
+                    .imageUrls(dto.getImageUrls())
+                    .isLiked(isLiked)
+                    .isVoted(dto.getIsVoted())
+                    .build();
+        });
         
         log.info("피드 타입별 조회 완료 - feedType: {}, 총 {}개, 현재 페이지 {}개", 
                 feedType, responsePage.getTotalElements(), responsePage.getNumberOfElements());

--- a/src/main/java/com/cMall/feedShop/feed/application/service/MyFeedReadService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/MyFeedReadService.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,17 +30,19 @@ public class MyFeedReadService {
     private final FeedRepository feedRepository;
     private final UserRepository userRepository;
     private final FeedMapper feedMapper;
+    private final FeedLikeService feedLikeService;
 
     /**
      * 사용자의 마이피드 목록 조회 (페이징)
      *
      * @param userId 사용자 ID
      * @param pageable 페이징 및 정렬 정보
+     * @param userDetails 사용자 정보 (선택적)
      * @return 마이피드 목록 페이지
      */
-    public Page<MyFeedListResponseDto> getMyFeeds(Long userId, Pageable pageable) {
-        log.info("마이피드 목록 조회 - userId: {}, page: {}, size: {}",
-                userId, pageable.getPageNumber(), pageable.getPageSize());
+    public Page<MyFeedListResponseDto> getMyFeeds(Long userId, Pageable pageable, UserDetails userDetails) {
+        log.info("마이피드 목록 조회 - userId: {}, page: {}, size: {}, userDetails: {}",
+                userId, pageable.getPageNumber(), pageable.getPageSize(), userDetails != null ? "있음" : "없음");
 
         // 사용자 존재 여부 확인
         User user = userRepository.findById(userId)
@@ -50,6 +53,35 @@ public class MyFeedReadService {
 
         // Feed 엔티티를 DTO로 변환
         Page<MyFeedListResponseDto> responsePage = feedPage.map(feedMapper::toMyFeedListResponseDto);
+
+        // 사용자별 좋아요 상태 설정
+        responsePage = responsePage.map(dto -> {
+            boolean isLiked = feedLikeService.isLikedByUser(dto.getFeedId(), userDetails);
+            return MyFeedListResponseDto.builder()
+                    .feedId(dto.getFeedId())
+                    .title(dto.getTitle())
+                    .content(dto.getContent())
+                    .feedType(dto.getFeedType())
+                    .instagramId(dto.getInstagramId())
+                    .createdAt(dto.getCreatedAt())
+                    .likeCount(dto.getLikeCount())
+                    .commentCount(dto.getCommentCount())
+                    .participantVoteCount(dto.getParticipantVoteCount())
+                    .userId(dto.getUserId())
+                    .userNickname(dto.getUserNickname())
+                    .userProfileImg(dto.getUserProfileImg())
+                    .userLevel(dto.getUserLevel())
+                    .orderItemId(dto.getOrderItemId())
+                    .productName(dto.getProductName())
+                    .productSize(dto.getProductSize())
+                    .eventId(dto.getEventId())
+                    .eventTitle(dto.getEventTitle())
+                    .hashtags(dto.getHashtags())
+                    .imageUrls(dto.getImageUrls())
+                    .isLiked(isLiked)
+                    .isVoted(dto.getIsVoted())
+                    .build();
+        });
 
         log.info("마이피드 목록 조회 완료 - userId: {}, 총 {}개, 현재 페이지 {}개",
                 userId, responsePage.getTotalElements(), responsePage.getNumberOfElements());
@@ -63,11 +95,12 @@ public class MyFeedReadService {
      * @param userId 사용자 ID
      * @param feedType 피드 타입
      * @param pageable 페이징 및 정렬 정보
+     * @param userDetails 사용자 정보 (선택적)
      * @return 마이피드 목록 페이지
      */
-    public Page<MyFeedListResponseDto> getMyFeedsByType(Long userId, FeedType feedType, Pageable pageable) {
-        log.info("마이피드 타입별 조회 - userId: {}, feedType: {}, page: {}, size: {}",
-                userId, feedType, pageable.getPageNumber(), pageable.getPageSize());
+    public Page<MyFeedListResponseDto> getMyFeedsByType(Long userId, FeedType feedType, Pageable pageable, UserDetails userDetails) {
+        log.info("마이피드 타입별 조회 - userId: {}, feedType: {}, page: {}, size: {}, userDetails: {}",
+                userId, feedType, pageable.getPageNumber(), pageable.getPageSize(), userDetails != null ? "있음" : "없음");
 
         // 사용자 존재 여부 확인
         User user = userRepository.findById(userId)
@@ -78,6 +111,35 @@ public class MyFeedReadService {
 
         // Feed 엔티티를 DTO로 변환
         Page<MyFeedListResponseDto> responsePage = feedPage.map(feedMapper::toMyFeedListResponseDto);
+
+        // 사용자별 좋아요 상태 설정
+        responsePage = responsePage.map(dto -> {
+            boolean isLiked = feedLikeService.isLikedByUser(dto.getFeedId(), userDetails);
+            return MyFeedListResponseDto.builder()
+                    .feedId(dto.getFeedId())
+                    .title(dto.getTitle())
+                    .content(dto.getContent())
+                    .feedType(dto.getFeedType())
+                    .instagramId(dto.getInstagramId())
+                    .createdAt(dto.getCreatedAt())
+                    .likeCount(dto.getLikeCount())
+                    .commentCount(dto.getCommentCount())
+                    .participantVoteCount(dto.getParticipantVoteCount())
+                    .userId(dto.getUserId())
+                    .userNickname(dto.getUserNickname())
+                    .userProfileImg(dto.getUserProfileImg())
+                    .userLevel(dto.getUserLevel())
+                    .orderItemId(dto.getOrderItemId())
+                    .productName(dto.getProductName())
+                    .productSize(dto.getProductSize())
+                    .eventId(dto.getEventId())
+                    .eventTitle(dto.getEventTitle())
+                    .hashtags(dto.getHashtags())
+                    .imageUrls(dto.getImageUrls())
+                    .isLiked(isLiked)
+                    .isVoted(dto.getIsVoted())
+                    .build();
+        });
 
         log.info("마이피드 타입별 조회 완료 - userId: {}, feedType: {}, 총 {}개, 현재 페이지 {}개",
                 userId, feedType, responsePage.getTotalElements(), responsePage.getNumberOfElements());
@@ -99,7 +161,6 @@ public class MyFeedReadService {
                 .orElseThrow(() -> new FeedAccessDeniedException(userId, "존재하지 않는 사용자입니다."));
 
         long count = feedRepository.countByUserId(userId);
-
         log.info("마이피드 개수 조회 완료 - userId: {}, 개수: {}", userId, count);
 
         return count;
@@ -120,7 +181,6 @@ public class MyFeedReadService {
                 .orElseThrow(() -> new FeedAccessDeniedException(userId, "존재하지 않는 사용자입니다."));
 
         long count = feedRepository.countByUserIdAndFeedType(userId, feedType.name());
-
         log.info("마이피드 타입별 개수 조회 완료 - userId: {}, feedType: {}, 개수: {}", userId, feedType, count);
 
         return count;

--- a/src/main/java/com/cMall/feedShop/feed/domain/FeedLike.java
+++ b/src/main/java/com/cMall/feedShop/feed/domain/FeedLike.java
@@ -34,18 +34,9 @@ public class FeedLike extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    /**
-     * 표시용 닉네임(비정규화 저장)
-     * - 목록 조회시 조인 없이 표시 가능
-     * - 변경 가능성 있으므로 최신값이 필요하면 UserProfile을 우선 조회
-     */
-    @Column(name = "nickname", length = 100)
-    private String nickname;
-
     @Builder
-    public FeedLike(Feed feed, User user, String nickname) {
+    public FeedLike(Feed feed, User user) {
         this.feed = feed;
         this.user = user;
-        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/cMall/feedShop/feed/domain/FeedLike.java
+++ b/src/main/java/com/cMall/feedShop/feed/domain/FeedLike.java
@@ -1,0 +1,51 @@
+package com.cMall.feedShop.feed.domain;
+
+import com.cMall.feedShop.common.BaseTimeEntity;
+import com.cMall.feedShop.user.domain.model.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "feed_likes",
+       uniqueConstraints = {
+           @UniqueConstraint(name = "uk_feed_like_feed_user", columnNames = {"feed_id", "user_id"})
+       },
+       indexes = {
+           @Index(name = "idx_feed_like_feed", columnList = "feed_id"),
+           @Index(name = "idx_feed_like_user", columnList = "user_id")
+       })
+public class FeedLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feed_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * 표시용 닉네임(비정규화 저장)
+     * - 목록 조회시 조인 없이 표시 가능
+     * - 변경 가능성 있으므로 최신값이 필요하면 UserProfile을 우선 조회
+     */
+    @Column(name = "nickname", length = 100)
+    private String nickname;
+
+    @Builder
+    public FeedLike(Feed feed, User user, String nickname) {
+        this.feed = feed;
+        this.user = user;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/domain/repository/FeedLikeRepository.java
+++ b/src/main/java/com/cMall/feedShop/feed/domain/repository/FeedLikeRepository.java
@@ -1,0 +1,20 @@
+package com.cMall.feedShop.feed.domain.repository;
+
+import com.cMall.feedShop.feed.domain.FeedLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+
+    boolean existsByFeed_IdAndUser_Id(Long feedId, Long userId);
+
+    void deleteByFeed_IdAndUser_Id(Long feedId, Long userId);
+
+    long countByFeed_Id(Long feedId);
+
+    @Query("select fl from FeedLike fl join fetch fl.user u where fl.feed.id = :feedId")
+    Page<FeedLike> findByFeedIdWithUser(@Param("feedId") Long feedId, Pageable pageable);
+}

--- a/src/main/java/com/cMall/feedShop/feed/domain/repository/FeedLikeRepository.java
+++ b/src/main/java/com/cMall/feedShop/feed/domain/repository/FeedLikeRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
 
     boolean existsByFeed_IdAndUser_Id(Long feedId, Long userId);
@@ -17,4 +19,7 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
 
     @Query("select fl from FeedLike fl join fetch fl.user u where fl.feed.id = :feedId")
     Page<FeedLike> findByFeedIdWithUser(@Param("feedId") Long feedId, Pageable pageable);
+
+    @Query("select fl.feed.id from FeedLike fl where fl.user.id = :userId")
+    List<Long> findFeedIdsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedDetailController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedDetailController.java
@@ -7,6 +7,8 @@ import com.cMall.feedShop.feed.application.service.FeedDetailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -24,14 +26,17 @@ public class FeedDetailController {
      * 피드 상세 조회 (FD-803)
      *
      * @param feedId 피드 ID
+     * @param userDetails 사용자 정보 (선택적)
      * @return 피드 상세 정보
      */
     @GetMapping("/{feedId}")
     @ApiResponseFormat(message = "요청하신 피드 상세 정보를 성공적으로 가져왔습니다.", status = 200)
-    public ResponseEntity<ApiResponse<FeedDetailResponseDto>> getFeedDetail(@PathVariable Long feedId) {
+    public ResponseEntity<ApiResponse<FeedDetailResponseDto>> getFeedDetail(
+            @PathVariable Long feedId,
+            @AuthenticationPrincipal UserDetails userDetails) {
         log.info("피드 상세 조회 요청 - feedId: {}", feedId);
 
-        FeedDetailResponseDto feedDetail = feedDetailService.getFeedDetail(feedId);
+        FeedDetailResponseDto feedDetail = feedDetailService.getFeedDetail(feedId, userDetails);
         return ResponseEntity.ok(ApiResponse.success(feedDetail));
     }
 }

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/feeds")
@@ -43,6 +45,14 @@ public class FeedLikeController {
             @RequestParam(defaultValue = "20") int size) {
         log.info("좋아요 사용자 목록 조회 요청 - feedId: {}, page: {}, size: {}", feedId, page, size);
         PaginatedResponse<LikeUserResponseDto> result = feedLikeService.getLikedUsers(feedId, page, size);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/my-likes")
+    @ApiResponseFormat(message = "내가 좋아요한 피드 목록입니다.", status = 200)
+    public ResponseEntity<ApiResponse<List<Long>>> getMyLikedFeeds(@AuthenticationPrincipal UserDetails userDetails) {
+        log.info("내 좋아요 피드 목록 조회 요청");
+        List<Long> result = feedLikeService.getMyLikedFeedIds(userDetails);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
@@ -1,0 +1,33 @@
+package com.cMall.feedShop.feed.presentation;
+
+import com.cMall.feedShop.common.aop.ApiResponseFormat;
+import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.service.FeedLikeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/feeds")
+@RequiredArgsConstructor
+public class FeedLikeController {
+
+    private final FeedLikeService feedLikeService;
+
+    @PostMapping("/{feedId}/likes/toggle")
+    @ApiResponseFormat(message = "좋아요 상태가 변경되었습니다.", status = 200)
+    public ResponseEntity<ApiResponse<LikeToggleResponseDto>> toggleLike(@PathVariable Long feedId,
+                                                                         @AuthenticationPrincipal UserDetails userDetails) {
+        log.info("좋아요 토글 요청 - feedId: {}", feedId);
+        LikeToggleResponseDto result = feedLikeService.toggleLike(feedId, userDetails);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
@@ -2,16 +2,20 @@ package com.cMall.feedShop.feed.presentation;
 
 import com.cMall.feedShop.common.aop.ApiResponseFormat;
 import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.common.dto.PaginatedResponse;
 import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.LikeUserResponseDto;
 import com.cMall.feedShop.feed.application.service.FeedLikeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -28,6 +32,17 @@ public class FeedLikeController {
                                                                          @AuthenticationPrincipal UserDetails userDetails) {
         log.info("좋아요 토글 요청 - feedId: {}", feedId);
         LikeToggleResponseDto result = feedLikeService.toggleLike(feedId, userDetails);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/{feedId}/likes")
+    @ApiResponseFormat(message = "좋아요 사용자 목록입니다.", status = 200)
+    public ResponseEntity<ApiResponse<PaginatedResponse<LikeUserResponseDto>>> getLikedUsers(
+            @PathVariable Long feedId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        log.info("좋아요 사용자 목록 조회 요청 - feedId: {}, page: {}, size: {}", feedId, page, size);
+        PaginatedResponse<LikeUserResponseDto> result = feedLikeService.getLikedUsers(feedId, page, size);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedReadController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedReadController.java
@@ -12,6 +12,8 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -33,6 +35,7 @@ public class FeedReadController {
      * @param page 페이지 번호 (기본값: 0)
      * @param size 페이지 크기 (기본값: 20)
      * @param sort 정렬 기준 (latest, popular)
+     * @param userDetails 사용자 정보 (선택적)
      * @return 피드 목록 페이지
      */
     @GetMapping
@@ -40,7 +43,8 @@ public class FeedReadController {
             @RequestParam(required = false) String feedType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "latest") String sort) {
+            @RequestParam(defaultValue = "latest") String sort,
+            @AuthenticationPrincipal UserDetails userDetails) {
         
         log.info("피드 목록 조회 요청 - feedType: {}, page: {}, size: {}, sort: {}", 
                 feedType, page, size, sort);
@@ -70,7 +74,7 @@ public class FeedReadController {
         Pageable pageable = PageRequest.of(page, size, sortConfig);
         
         // 서비스 호출
-        Page<FeedListResponseDto> feedPage = feedReadService.getFeeds(type, pageable);
+        Page<FeedListResponseDto> feedPage = feedReadService.getFeeds(type, pageable, userDetails);
         
         // 응답 생성
         PaginatedResponse<FeedListResponseDto> response = PaginatedResponse.<FeedListResponseDto>builder()
@@ -96,6 +100,7 @@ public class FeedReadController {
      * @param page 페이지 번호 (기본값: 0)
      * @param size 페이지 크기 (기본값: 20)
      * @param sort 정렬 기준 (latest, popular)
+     * @param userDetails 사용자 정보 (선택적)
      * @return 피드 목록 페이지
      */
     @GetMapping("/type/{feedType}")
@@ -103,7 +108,8 @@ public class FeedReadController {
             @PathVariable String feedType,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size,
-            @RequestParam(defaultValue = "latest") String sort) {
+            @RequestParam(defaultValue = "latest") String sort,
+            @AuthenticationPrincipal UserDetails userDetails) {
         
         log.info("피드 타입별 조회 요청 - feedType: {}, page: {}, size: {}, sort: {}", 
                 feedType, page, size, sort);
@@ -124,7 +130,7 @@ public class FeedReadController {
             Pageable pageable = PageRequest.of(page, size, sortConfig);
             
             // 서비스 호출
-            Page<FeedListResponseDto> feedPage = feedReadService.getFeedsByType(type, pageable);
+            Page<FeedListResponseDto> feedPage = feedReadService.getFeedsByType(type, pageable, userDetails);
             
             // 응답 생성
             PaginatedResponse<FeedListResponseDto> response = PaginatedResponse.<FeedListResponseDto>builder()

--- a/src/main/java/com/cMall/feedShop/feed/presentation/MyFeedReadController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/MyFeedReadController.java
@@ -89,9 +89,9 @@ public class MyFeedReadController {
         // 서비스 호출
         Page<MyFeedListResponseDto> feedPage;
         if (type != null) {
-            feedPage = myFeedReadService.getMyFeedsByType(userId, type, pageable);
+            feedPage = myFeedReadService.getMyFeedsByType(userId, type, pageable, userDetails);
         } else {
-            feedPage = myFeedReadService.getMyFeeds(userId, pageable);
+            feedPage = myFeedReadService.getMyFeeds(userId, pageable, userDetails);
         }
 
         // 응답 생성
@@ -155,7 +155,7 @@ public class MyFeedReadController {
             Pageable pageable = PageRequest.of(page, size, sortConfig);
 
             // 서비스 호출
-            Page<MyFeedListResponseDto> feedPage = myFeedReadService.getMyFeedsByType(userId, type, pageable);
+            Page<MyFeedListResponseDto> feedPage = myFeedReadService.getMyFeedsByType(userId, type, pageable, userDetails);
 
             // 응답 생성
             PaginatedResponse<MyFeedListResponseDto> response = PaginatedResponse.<MyFeedListResponseDto>builder()

--- a/src/test/java/com/cMall/feedShop/feed/application/service/FeedDetailServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/feed/application/service/FeedDetailServiceTest.java
@@ -5,8 +5,10 @@ import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
 import com.cMall.feedShop.feed.domain.Feed;
 import com.cMall.feedShop.feed.domain.FeedType;
 import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.feed.domain.repository.FeedLikeRepository;
 import com.cMall.feedShop.order.domain.model.OrderItem;
 import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -30,6 +33,12 @@ class FeedDetailServiceTest {
 
     @Mock
     private FeedMapper feedMapper;
+
+    @Mock
+    private FeedLikeRepository feedLikeRepository;
+
+    @Mock
+    private UserRepository userRepository;
 
     @InjectMocks
     private FeedDetailService feedDetailService;
@@ -72,15 +81,15 @@ class FeedDetailServiceTest {
     }
 
     @Test
-    @DisplayName("피드 상세 조회 성공")
-    void getFeedDetail_Success() {
+    @DisplayName("피드 상세 조회 성공 - 로그인하지 않은 사용자")
+    void getFeedDetail_Success_WithoutUser() {
         // given
         Long feedId = 1L;
         when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(mockFeed));
         when(feedMapper.toFeedDetailResponseDto(mockFeed)).thenReturn(mockResponseDto);
 
         // when
-        FeedDetailResponseDto result = feedDetailService.getFeedDetail(feedId);
+        FeedDetailResponseDto result = feedDetailService.getFeedDetail(feedId, null);
 
         // then
         assertThat(result).isNotNull();
@@ -91,6 +100,55 @@ class FeedDetailServiceTest {
         assertThat(result.getLikeCount()).isEqualTo(10);
         assertThat(result.getCommentCount()).isEqualTo(5);
         assertThat(result.getParticipantVoteCount()).isEqualTo(3);
+        assertThat(result.getIsLiked()).isFalse(); // 로그인하지 않은 사용자는 false
+    }
+
+    @Test
+    @DisplayName("피드 상세 조회 성공 - 로그인한 사용자 (좋아요하지 않은 상태)")
+    void getFeedDetail_Success_WithUser_NotLiked() {
+        // given
+        Long feedId = 1L;
+        UserDetails userDetails = org.mockito.Mockito.mock(UserDetails.class);
+        User mockUser = new User(1L, "testuser", "password", "test@test.com", com.cMall.feedShop.user.domain.enums.UserRole.USER);
+        
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(mockFeed));
+        when(feedMapper.toFeedDetailResponseDto(mockFeed)).thenReturn(mockResponseDto);
+        when(userDetails.getUsername()).thenReturn("testuser");
+        when(userRepository.findByLoginId("testuser")).thenReturn(Optional.of(mockUser));
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, mockUser.getId())).thenReturn(false);
+
+        // when
+        FeedDetailResponseDto result = feedDetailService.getFeedDetail(feedId, userDetails);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getFeedId()).isEqualTo(feedId);
+        assertThat(result.getTitle()).isEqualTo("테스트 피드");
+        assertThat(result.getIsLiked()).isFalse(); // 좋아요하지 않은 상태
+    }
+
+    @Test
+    @DisplayName("피드 상세 조회 성공 - 로그인한 사용자 (좋아요한 상태)")
+    void getFeedDetail_Success_WithUser_Liked() {
+        // given
+        Long feedId = 1L;
+        UserDetails userDetails = org.mockito.Mockito.mock(UserDetails.class);
+        User mockUser = new User(1L, "testuser", "password", "test@test.com", com.cMall.feedShop.user.domain.enums.UserRole.USER);
+        
+        when(feedRepository.findDetailById(feedId)).thenReturn(Optional.of(mockFeed));
+        when(feedMapper.toFeedDetailResponseDto(mockFeed)).thenReturn(mockResponseDto);
+        when(userDetails.getUsername()).thenReturn("testuser");
+        when(userRepository.findByLoginId("testuser")).thenReturn(Optional.of(mockUser));
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, mockUser.getId())).thenReturn(true);
+
+        // when
+        FeedDetailResponseDto result = feedDetailService.getFeedDetail(feedId, userDetails);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getFeedId()).isEqualTo(feedId);
+        assertThat(result.getTitle()).isEqualTo("테스트 피드");
+        assertThat(result.getIsLiked()).isTrue(); // 좋아요한 상태
     }
 
     @Test
@@ -101,7 +159,7 @@ class FeedDetailServiceTest {
         when(feedRepository.findDetailById(feedId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> feedDetailService.getFeedDetail(feedId))
+        assertThatThrownBy(() -> feedDetailService.getFeedDetail(feedId, null))
                 .isInstanceOf(FeedNotFoundException.class)
                 .hasMessageContaining("피드를 찾을 수 없습니다");
     }
@@ -117,7 +175,7 @@ class FeedDetailServiceTest {
         when(feedRepository.findDetailById(feedId)).thenReturn(Optional.empty());
 
         // when & then
-        assertThatThrownBy(() -> feedDetailService.getFeedDetail(feedId))
+        assertThatThrownBy(() -> feedDetailService.getFeedDetail(feedId, null))
                 .isInstanceOf(FeedNotFoundException.class)
                 .hasMessageContaining("피드를 찾을 수 없습니다");
     }

--- a/src/test/java/com/cMall/feedShop/feed/application/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/feed/application/service/FeedLikeServiceTest.java
@@ -1,0 +1,135 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.repository.FeedLikeRepository;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.order.domain.model.OrderItem;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedLikeServiceTest {
+
+    @Mock private FeedLikeRepository feedLikeRepository;
+    @Mock private FeedRepository feedRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private UserDetails userDetails;
+
+    @InjectMocks private FeedLikeService feedLikeService;
+
+    private User user;
+    private Feed feed;
+
+    @BeforeEach
+    void setUp() {
+        user = new User(1L, "login", "pwd", "email@test.com", UserRole.USER);
+        OrderItem orderItem = OrderItem.builder()
+                .quantity(1)
+                .totalPrice(java.math.BigDecimal.valueOf(10000))
+                .finalPrice(java.math.BigDecimal.valueOf(9000))
+                .build();
+        feed = Feed.builder()
+                .user(user)
+                .orderItem(orderItem)
+                .title("t")
+                .content("c")
+                .instagramId("i")
+                .build();
+    }
+
+    @Test
+    @DisplayName("좋아요 추가 - 존재하지 않으면 생성하고 likeCount 증가")
+    void toggleLike_add() {
+        Long feedId = 10L;
+        when(userDetails.getUsername()).thenReturn("login");
+        when(userRepository.findByLoginId("login")).thenReturn(Optional.of(user));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, user.getId())).thenReturn(false);
+
+        LikeToggleResponseDto res = feedLikeService.toggleLike(feedId, userDetails);
+
+        assertThat(res.isLiked()).isTrue();
+        assertThat(res.getLikeCount()).isEqualTo(feed.getLikeCount());
+        verify(feedLikeRepository, times(1)).save(any());
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 - 존재하면 삭제하고 likeCount 감소")
+    void toggleLike_remove() {
+        Long feedId = 11L;
+        // 초기 likeCount를 1로 만들어서 감소 확인
+        feed.incrementLikeCount();
+        when(userDetails.getUsername()).thenReturn("login");
+        when(userRepository.findByLoginId("login")).thenReturn(Optional.of(user));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, user.getId())).thenReturn(true);
+
+        LikeToggleResponseDto res = feedLikeService.toggleLike(feedId, userDetails);
+
+        assertThat(res.isLiked()).isFalse();
+        assertThat(res.getLikeCount()).isEqualTo(feed.getLikeCount());
+        verify(feedLikeRepository, times(1)).deleteByFeed_IdAndUser_Id(feedId, user.getId());
+    }
+
+    @Test
+    @DisplayName("미인증 401")
+    void toggleLike_unauthorized() {
+        Long feedId = 12L;
+        assertThatThrownBy(() -> feedLikeService.toggleLike(feedId, null))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.UNAUTHORIZED));
+    }
+
+    @Test
+    @DisplayName("사용자 없음 USER_NOT_FOUND")
+    void toggleLike_userNotFound() {
+        Long feedId = 13L;
+        when(userDetails.getUsername()).thenReturn("unknown");
+        when(userRepository.findByLoginId("unknown")).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> feedLikeService.toggleLike(feedId, userDetails))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("피드 없음 404")
+    void toggleLike_feedNotFound() {
+        Long feedId = 14L;
+        when(userDetails.getUsername()).thenReturn("login");
+        when(userRepository.findByLoginId("login")).thenReturn(Optional.of(user));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.empty());
+        assertThatThrownBy(() -> feedLikeService.toggleLike(feedId, userDetails))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("삭제된 피드 404")
+    void toggleLike_deletedFeed() {
+        Long feedId = 15L;
+        when(userDetails.getUsername()).thenReturn("login");
+        when(userRepository.findByLoginId("login")).thenReturn(Optional.of(user));
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+        feed.softDelete();
+        assertThatThrownBy(() -> feedLikeService.toggleLike(feedId, userDetails))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+}

--- a/src/test/java/com/cMall/feedShop/feed/application/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/feed/application/service/FeedLikeServiceTest.java
@@ -1,10 +1,13 @@
 package com.cMall.feedShop.feed.application.service;
 
+import com.cMall.feedShop.common.dto.PaginatedResponse;
 import com.cMall.feedShop.common.exception.BusinessException;
 import com.cMall.feedShop.common.exception.ErrorCode;
 import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.LikeUserResponseDto;
 import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
 import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.FeedLike;
 import com.cMall.feedShop.feed.domain.repository.FeedLikeRepository;
 import com.cMall.feedShop.feed.domain.repository.FeedRepository;
 import com.cMall.feedShop.order.domain.model.OrderItem;
@@ -18,8 +21,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -131,5 +140,91 @@ class FeedLikeServiceTest {
         feed.softDelete();
         assertThatThrownBy(() -> feedLikeService.toggleLike(feedId, userDetails))
                 .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    // ========== 좋아요 사용자 목록 조회 테스트 ==========
+    
+    @Test
+    @DisplayName("좋아요 사용자 목록 조회 성공")
+    void getLikedUsers_success() {
+        // given
+        Long feedId = 20L;
+        int page = 0;
+        int size = 10;
+        
+        User user1 = new User(1L, "user1", "pwd", "user1@test.com", UserRole.USER);
+        User user2 = new User(2L, "user2", "pwd", "user2@test.com", UserRole.USER);
+        
+        FeedLike feedLike1 = FeedLike.builder()
+                .feed(feed)
+                .user(user1)
+                .build();
+        FeedLike feedLike2 = FeedLike.builder()
+                .feed(feed)
+                .user(user2)
+                .build();
+        
+        List<FeedLike> feedLikes = List.of(feedLike1, feedLike2);
+        Page<FeedLike> feedLikePage = new PageImpl<>(feedLikes, PageRequest.of(page, size), 2);
+        
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+        when(feedLikeRepository.findByFeedIdWithUser(eq(feedId), any(Pageable.class)))
+                .thenReturn(feedLikePage);
+        
+        // when
+        PaginatedResponse<LikeUserResponseDto> result = feedLikeService.getLikedUsers(feedId, page, size);
+        
+        // then
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getPage()).isEqualTo(page);
+        assertThat(result.getSize()).isEqualTo(size);
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getTotalPages()).isEqualTo(1);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.isHasPrevious()).isFalse();
+        
+        // 첫 번째 사용자 검증
+        LikeUserResponseDto firstUser = result.getContent().get(0);
+        assertThat(firstUser.getUserId()).isEqualTo(user1.getId());
+        
+        verify(feedRepository, times(1)).findById(feedId);
+        verify(feedLikeRepository, times(1)).findByFeedIdWithUser(eq(feedId), any(Pageable.class));
+    }
+    
+    @Test
+    @DisplayName("좋아요 사용자 목록 조회 - 피드 없음 404")
+    void getLikedUsers_feedNotFound() {
+        // given
+        Long feedId = 21L;
+        int page = 0;
+        int size = 10;
+        
+        when(feedRepository.findById(feedId)).thenReturn(Optional.empty());
+        
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.getLikedUsers(feedId, page, size))
+                .isInstanceOf(FeedNotFoundException.class);
+        
+        verify(feedRepository, times(1)).findById(feedId);
+        verify(feedLikeRepository, never()).findByFeedIdWithUser(any(), any());
+    }
+    
+    @Test
+    @DisplayName("좋아요 사용자 목록 조회 - 삭제된 피드 404")
+    void getLikedUsers_deletedFeed() {
+        // given
+        Long feedId = 22L;
+        int page = 0;
+        int size = 10;
+        
+        feed.softDelete();
+        when(feedRepository.findById(feedId)).thenReturn(Optional.of(feed));
+        
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.getLikedUsers(feedId, page, size))
+                .isInstanceOf(FeedNotFoundException.class);
+        
+        verify(feedRepository, times(1)).findById(feedId);
+        verify(feedLikeRepository, never()).findByFeedIdWithUser(any(), any());
     }
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -40,4 +40,3 @@ file.upload.base-path=./test-uploads
 file.upload.cache-period=3600
 
 app.cdn.base-url=https://mock-cdn.example.com
-


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
피드 좋아요 기능의 백엔드 리팩토링과 프론트엔드 개선을 통해 **모든 페이지에서 일관된 좋아요 상태**를 유지합니다.

**Type**
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [X] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- 피드 상세 페이지에서만 좋아요 상태가 유지되고, 다른 페이지에서는 사라짐
- 3개 서비스에서 동일한 좋아요 상태 확인 로직이 중복(유지보수 어려움)
- FeedMapper에서 `isLiked`가 하드코딩되어 실제 상태 반영 안 됨

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
- **일관성**: 모든 페이지에서 동일한 좋아요 표시.
- **유지보수성**: 중복 로직 제거.
- **정확성**: 백엔드에서 실제 좋아요 상태 반영

---

## 🔧 How (구현 방법)
### 주요 변경사항
- **공통 메서드**: `FeedLikeService.isLikedByUser()` 추가 (중복 코드 약 **180줄 → 3줄**)
- **서비스 개선**: FeedDetailService, FeedReadService, MyFeedReadService에서 공통 메서드 활용
- **컨트롤러 수정**: 모든 피드 조회 API에 `@AuthenticationPrincipal UserDetails` 추가
- **Mapper 개선**: `isLiked`, `isVoted`를 null로 초기화 → 서비스에서 동적 설정
- **신규 API**: `GET /api/feeds/my-likes` (사용자별 좋아요 피드 목록 조회)
- **Repository**: `FeedLikeRepository.findFeedIdsByUserId()` 추가

### 기술적 접근
DRY 원칙 적용
```
// 이전: 3개 서비스에 동일한 로직 중복
if (userDetails != null && userDetails.getUsername() != null) {
    try {
        User user = userRepository.findByLoginId(userDetails.getUsername()).orElse(null);
        if (user != null) {
            boolean isLiked = feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, user.getId());
            // DTO 빌더로 isLiked 설정...
        }
    } catch (Exception e) {
        log.warn("사용자별 좋아요 상태 확인 실패 - error: {}", e.getMessage());
    }
}
단일 책임 원칙
- FeedLikeService: 좋아요 관련 모든 로직 담당
- 다른 서비스들: 각자의 도메인 로직만 담당

// 현재: 공통 메서드 활용
boolean isLiked = feedLikeService.isLikedByUser(feedId, userDetails);
```

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
- Unit: `FeedLikeService.isLikedByUser()` 정상 동작 확인
- Integration: 모든 피드 조회 API에서 `isLiked` 정확히 반영
- Scenario: 로그인/비로그인 사용자별 상태 검증

### 확인 사항
- [X] 기능 정상 동작 확인
- [X] 기존 기능 영향 없음
- [X] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #166
- 지라 백로그: MYCE-97
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
- **개선 효과**
  - 좋아요 로직 변경 시 한 곳만 수정
- **호환성**
  - 기존 API 유지
  - 신규 API 점진적 적용
- **주의사항**
  - 인증 필수 (로그인 안 한 사용자는 `isLiked: false`)
---

## ✅ Checklist
- [X] 코드 리뷰 준비 완료
- [X] 테스트 완료
- [X] 불필요한 로그 제거
