### PR TITLE
MYCE-243 : feat/feed - myLikeFeedList api  구현

### DIFF
--- a/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeToggleResponseDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeToggleResponseDto.java
@@ -1,0 +1,15 @@
+package com.cMall.feedShop.feed.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LikeToggleResponseDto {
+    private boolean liked;
+    private int likeCount;
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeUserResponseDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/response/LikeUserResponseDto.java
@@ -1,0 +1,44 @@
+package com.cMall.feedShop.feed.application.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 좋아요 사용자 정보 응답 DTO
+ */
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LikeUserResponseDto {
+    
+    /**
+     * 사용자 ID
+     */
+    private Long userId;
+    
+    /**
+     * 사용자 닉네임
+     */
+    private String nickname;
+    
+    /**
+     * 프로필 이미지 URL
+     */
+    private String profileImageUrl;
+    
+    /**
+     * 사용자 레벨
+     */
+    private Integer level;
+    
+    /**
+     * 좋아요 누른 시간
+     */
+    private LocalDateTime likedAt;
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/dto/response/MyLikedFeedItemDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/response/MyLikedFeedItemDto.java
@@ -1,0 +1,65 @@
+package com.cMall.feedShop.feed.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 좋아요한 피드 개별 아이템 응답 DTO
+ * 사용자가 좋아요를 누른 피드의 기본 정보와 좋아요 시간을 제공
+ */
+@Getter
+@Builder
+public class MyLikedFeedItemDto {
+    
+    /**
+     * 피드 ID
+     */
+    private final Long feedId;
+    
+    /**
+     * 피드 제목
+     */
+    private final String title;
+    
+    /**
+     * 피드 내용 (일부만 표시)
+     */
+    private final String content;
+    
+    /**
+     * 피드 타입 (DAILY, EVENT, RANKING)
+     */
+    private final String feedType;
+    
+    /**
+     * 대표 이미지 URL
+     */
+    private final String imageUrl;
+    
+    /**
+     * 좋아요를 누른 시간
+     */
+    private final LocalDateTime likedAt;
+    
+    /**
+     * 현재 좋아요 수
+     */
+    private final int likeCount;
+    
+    /**
+     * 현재 댓글 수
+     */
+    private final int commentCount;
+    
+    /**
+     * 피드 작성자 닉네임
+     */
+    private final String authorNickname;
+    
+    /**
+     * 피드 작성자 프로필 이미지
+     */
+    private final String authorProfileImage;
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/dto/response/MyLikedFeedsResponseDto.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/dto/response/MyLikedFeedsResponseDto.java
@@ -1,0 +1,60 @@
+package com.cMall.feedShop.feed.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 좋아요한 피드 목록 응답 DTO
+ * 페이징 정보와 함께 사용자가 좋아요를 누른 피드 목록을 제공
+ */
+@Getter
+@Builder
+public class MyLikedFeedsResponseDto {
+    
+    /**
+     * 좋아요한 피드 목록
+     */
+    private final List<MyLikedFeedItemDto> content;
+    
+    /**
+     * 현재 페이지 (0부터 시작)
+     */
+    private final int page;
+    
+    /**
+     * 페이지 크기
+     */
+    private final int size;
+    
+    /**
+     * 전체 피드 개수
+     */
+    private final long totalElements;
+    
+    /**
+     * 전체 페이지 수
+     */
+    private final int totalPages;
+    
+    /**
+     * 첫 번째 페이지 여부
+     */
+    private final boolean first;
+    
+    /**
+     * 마지막 페이지 여부
+     */
+    private final boolean last;
+    
+    /**
+     * 다음 페이지 존재 여부
+     */
+    private final boolean hasNext;
+    
+    /**
+     * 이전 페이지 존재 여부
+     */
+    private final boolean hasPrevious;
+}

--- a/src/main/java/com/cMall/feedShop/feed/application/service/FeedLikeService.java
+++ b/src/main/java/com/cMall/feedShop/feed/application/service/FeedLikeService.java
@@ -1,0 +1,273 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.common.dto.PaginatedResponse;
+import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.LikeUserResponseDto;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.FeedLike;
+import com.cMall.feedShop.feed.domain.repository.FeedLikeRepository;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import com.cMall.feedShop.feed.application.dto.response.MyLikedFeedsResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.MyLikedFeedItemDto;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedLikeService {
+
+    private final FeedLikeRepository feedLikeRepository;
+    private final FeedRepository feedRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 좋아요 토글
+     * - 없으면 생성(liked=true), 있으면 삭제(liked=false)
+     * - Feed.likeCount 증감
+     */
+    @Transactional
+    public LikeToggleResponseDto toggleLike(Long feedId, Long userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "인증이 필요합니다.");
+        }
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedNotFoundException(feedId));
+        if (feed.isDeleted()) {
+            throw new FeedNotFoundException(feedId);
+        }
+
+        boolean exists = feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, user.getId());
+        boolean liked;
+        if (exists) {
+            // 취소
+            feedLikeRepository.deleteByFeed_IdAndUser_Id(feedId, user.getId());
+            feed.decrementLikeCount();
+            liked = false;
+        } else {
+            // 추가
+            feedLikeRepository.save(FeedLike.builder()
+                    .feed(feed)
+                    .user(user)
+                    .build());
+            feed.incrementLikeCount();
+            liked = true;
+        }
+
+        int likeCount = feed.getLikeCount() != null ? feed.getLikeCount() : 0;
+        return LikeToggleResponseDto.builder()
+                .liked(liked)
+                .likeCount(likeCount)
+                .build();
+    }
+
+    /**
+     * 좋아요 사용자 목록 조회
+     * - 피드 존재/삭제 여부 검증
+     * - 좋아요 누른 시간 기준 내림차순 정렬
+     * - 페이징 지원
+     */
+    @Transactional(readOnly = true)
+    public PaginatedResponse<LikeUserResponseDto> getLikedUsers(Long feedId, int page, int size) {
+        log.info("좋아요 사용자 목록 조회 요청 - feedId: {}, page: {}, size: {}", feedId, page, size);
+        
+        // 피드 존재 및 삭제 여부 검증
+        Feed feed = feedRepository.findById(feedId)
+                .orElseThrow(() -> new FeedNotFoundException(feedId));
+        if (feed.isDeleted()) {
+            log.warn("삭제된 피드의 좋아요 사용자 목록 조회 시도 - feedId: {}", feedId);
+            throw new FeedNotFoundException(feedId);
+        }
+        
+        // 페이징 및 정렬 설정
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        
+        // 좋아요 사용자 목록 조회 (User 정보 포함)
+        Page<FeedLike> feedLikes = feedLikeRepository.findByFeedIdWithUser(feedId, pageRequest);
+        
+        // DTO 변환
+        List<LikeUserResponseDto> likeUsers = feedLikes.getContent().stream()
+                .map(this::toLikeUserResponseDto)
+                .collect(Collectors.toList());
+        
+        log.info("좋아요 사용자 목록 조회 완료 - feedId: {}, 총 {}명", feedId, feedLikes.getTotalElements());
+        
+        // PaginatedResponse 구성
+        return PaginatedResponse.<LikeUserResponseDto>builder()
+                .content(likeUsers)
+                .page(page)
+                .size(size)
+                .totalElements(feedLikes.getTotalElements())
+                .totalPages(feedLikes.getTotalPages())
+                .hasNext(feedLikes.hasNext())
+                .hasPrevious(feedLikes.hasPrevious())
+                .build();
+    }
+
+    /**
+     * 사용자가 좋아요한 피드 ID 목록 조회
+     * - 로그인한 사용자가 좋아요를 누른 모든 피드 ID 반환
+     * - 프론트엔드에서 좋아요 상태 복원용
+     */
+    @Transactional(readOnly = true)
+    public List<Long> getMyLikedFeedIds(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElse(null);
+        
+        if (user == null) {
+            log.warn("사용자를 찾을 수 없어서 좋아요 피드 목록을 조회할 수 없습니다. - userId: {}", userId);
+            return List.of();
+        }
+        
+        log.info("사용자별 좋아요 피드 목록 조회 - userId: {}", user.getId());
+        
+        List<Long> likedFeedIds = feedLikeRepository.findFeedIdsByUserId(user.getId());
+        
+        log.info("사용자별 좋아요 피드 목록 조회 완료 - userId: {}, 좋아요한 피드 수: {}", user.getId(), likedFeedIds.size());
+        
+        return likedFeedIds;
+    }
+    
+    /**
+     * FeedLike 엔티티를 LikeUserResponseDto로 변환
+     */
+    private LikeUserResponseDto toLikeUserResponseDto(FeedLike feedLike) {
+        User user = feedLike.getUser();
+        return LikeUserResponseDto.builder()
+                .userId(user.getId())
+                .nickname(getUserNickname(user))
+                .profileImageUrl(getUserProfileImageUrl(user))
+                .level(getUserLevel(user))
+                .likedAt(feedLike.getCreatedAt())
+                .build();
+    }
+    
+    /**
+     * 사용자 닉네임 조회
+     */
+    private String getUserNickname(User user) {
+        if (user.getUserProfile() != null) {
+            return user.getUserProfile().getNickname();
+        }
+        return null;
+    }
+    
+    /**
+     * 사용자 프로필 이미지 URL 조회
+     */
+    private String getUserProfileImageUrl(User user) {
+        // TODO: 추후 UserProfile에 profileImageUrl 필드 추가 시 구현
+        return null;
+    }
+    
+    /**
+     * 사용자 레벨 조회
+     */
+    private Integer getUserLevel(User user) {
+        // TODO: 추후 UserProfile에 level 필드 추가 시 구현
+        return null;
+    }
+    
+    /**
+     * 사용자별 좋아요 상태 확인
+     * - 공통으로 사용되는 좋아요 상태 확인 로직
+     * - 다른 서비스에서 호출하여 사용
+     */
+    public boolean isLikedByUser(Long feedId, Long userId) {
+        try {
+            return feedLikeRepository.existsByFeed_IdAndUser_Id(feedId, userId);
+        } catch (Exception e) {
+            log.warn("사용자별 좋아요 상태 확인 실패 - feedId: {}, userId: {}, error: {}", feedId, userId, e.getMessage());
+            return false;
+        }
+    }
+    
+    /**
+     * 사용자가 좋아요한 피드 목록 조회 (페이징)
+     * - 로그인한 사용자가 좋아요를 누른 피드들을 페이징으로 조회
+     * - 좋아요를 누른 시간순으로 정렬 (최신순)
+     * - 피드 상세 정보와 함께 좋아요 시간 제공
+     */
+    @Transactional(readOnly = true)
+    public MyLikedFeedsResponseDto getMyLikedFeeds(Long userId, int page, int size) {
+        log.info("사용자별 좋아요 피드 목록 조회 요청 - userId: {}, page: {}, size: {}", userId, page, size);
+        
+        // 사용자 존재 여부 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        
+        // 페이징 및 정렬 설정
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        
+        // 사용자가 좋아요한 피드 목록 조회
+        Page<FeedLike> feedLikes = feedLikeRepository.findByUserIdWithFeed(userId, pageRequest);
+        
+        // DTO 변환
+        List<MyLikedFeedItemDto> likedFeeds = feedLikes.getContent().stream()
+                .map(this::toMyLikedFeedItemDto)
+                .collect(Collectors.toList());
+        
+        log.info("사용자별 좋아요 피드 목록 조회 완료 - userId: {}, 총 {}개", userId, feedLikes.getTotalElements());
+        
+        // MyLikedFeedsResponseDto 구성
+        return MyLikedFeedsResponseDto.builder()
+                .content(likedFeeds)
+                .page(page)
+                .size(size)
+                .totalElements(feedLikes.getTotalElements())
+                .totalPages(feedLikes.getTotalPages())
+                .first(feedLikes.isFirst())
+                .last(feedLikes.isLast())
+                .hasNext(feedLikes.hasNext())
+                .hasPrevious(feedLikes.hasPrevious())
+                .build();
+    }
+    
+    /**
+     * FeedLike 엔티티를 MyLikedFeedItemDto로 변환
+     */
+    private MyLikedFeedItemDto toMyLikedFeedItemDto(FeedLike feedLike) {
+        Feed feed = feedLike.getFeed();
+        User author = feed.getUser();
+        
+        return MyLikedFeedItemDto.builder()
+                .feedId(feed.getId())
+                .title(feed.getTitle())
+                .content(feed.getContent())
+                .feedType(feed.getFeedType().name())
+                .imageUrl(getFirstImageUrl(feed))
+                .likedAt(feedLike.getCreatedAt())
+                .likeCount(feed.getLikeCount() != null ? feed.getLikeCount() : 0)
+                .commentCount(feed.getCommentCount() != null ? feed.getCommentCount() : 0)
+                .authorNickname(getUserNickname(author))
+                .authorProfileImage(getUserProfileImageUrl(author))
+                .build();
+    }
+    
+    /**
+     * 피드의 첫 번째 이미지 URL 조회
+     */
+    private String getFirstImageUrl(Feed feed) {
+        // TODO: Feed 엔티티에 images 관계가 있다면 첫 번째 이미지 URL 반환
+        // 현재는 null 반환
+        return null;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/domain/FeedLike.java
+++ b/src/main/java/com/cMall/feedShop/feed/domain/FeedLike.java
@@ -1,0 +1,42 @@
+package com.cMall.feedShop.feed.domain;
+
+import com.cMall.feedShop.common.BaseTimeEntity;
+import com.cMall.feedShop.user.domain.model.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "feed_likes",
+       uniqueConstraints = {
+           @UniqueConstraint(name = "uk_feed_like_feed_user", columnNames = {"feed_id", "user_id"})
+       },
+       indexes = {
+           @Index(name = "idx_feed_like_feed", columnList = "feed_id"),
+           @Index(name = "idx_feed_like_user", columnList = "user_id")
+       })
+public class FeedLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "feed_like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public FeedLike(Feed feed, User user) {
+        this.feed = feed;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/domain/repository/FeedLikeRepository.java
+++ b/src/main/java/com/cMall/feedShop/feed/domain/repository/FeedLikeRepository.java
@@ -1,0 +1,32 @@
+package com.cMall.feedShop.feed.domain.repository;
+
+import com.cMall.feedShop.feed.domain.FeedLike;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+
+    boolean existsByFeed_IdAndUser_Id(Long feedId, Long userId);
+
+    void deleteByFeed_IdAndUser_Id(Long feedId, Long userId);
+
+    long countByFeed_Id(Long feedId);
+
+    @Query("select fl from FeedLike fl join fetch fl.user u where fl.feed.id = :feedId")
+    Page<FeedLike> findByFeedIdWithUser(@Param("feedId") Long feedId, Pageable pageable);
+    
+    /**
+     * 사용자별 좋아요 피드 목록 조회 (페이징)
+     * 피드 정보와 함께 좋아요 시간을 포함하여 조회
+     */
+    @Query("select fl from FeedLike fl join fetch fl.feed f join fetch f.user u where fl.user.id = :userId order by fl.createdAt desc")
+    Page<FeedLike> findByUserIdWithFeed(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("select fl.feed.id from FeedLike fl where fl.user.id = :userId")
+    List<Long> findFeedIdsByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
@@ -108,26 +108,18 @@ public class FeedLikeController {
             return null;
         }
 
-        String username = userDetails.getUsername(); // JWT 토큰의 subject
-        log.debug("UserDetails에서 추출한 username: {}", username);
+        String email = userDetails.getUsername(); // JWT 토큰의 subject는 email
+        log.info("UserDetails에서 추출한 email: {}", email);
 
-        // 1. 먼저 email로 시도
-        Optional<User> userOptional = userRepository.findByEmail(username);
+        // JWT 토큰의 subject가 email이므로 findByEmail 사용
+        Optional<User> userOptional = userRepository.findByEmail(email);
         if (userOptional.isPresent()) {
             User user = userOptional.get();
-            log.debug("email로 사용자 찾음 - ID: {} (email: {})", user.getId(), username);
+            log.info("사용자 ID 추출 완료: {} (email: {})", user.getId(), email);
             return user.getId();
         }
 
-        // 2. email로 찾지 못하면 loginId로 시도
-        userOptional = userRepository.findByLoginId(username);
-        if (userOptional.isPresent()) {
-            User user = userOptional.get();
-            log.debug("loginId로 사용자 찾음 - ID: {} (loginId: {})", user.getId(), username);
-            return user.getId();
-        }
-
-        log.warn("username '{}'로 사용자를 찾을 수 없습니다 (email, loginId 모두 시도)", username);
+        log.warn("email '{}'로 사용자를 찾을 수 없습니다", email);
         return null;
     }
 }

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
@@ -1,0 +1,124 @@
+package com.cMall.feedShop.feed.presentation;
+
+import com.cMall.feedShop.common.aop.ApiResponseFormat;
+import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.common.dto.PaginatedResponse;
+import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.LikeUserResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.MyLikedFeedsResponseDto;
+import com.cMall.feedShop.feed.application.service.FeedLikeService;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/feeds")
+@RequiredArgsConstructor
+public class FeedLikeController {
+
+    private final FeedLikeService feedLikeService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/{feedId}/likes/toggle")
+    @ApiResponseFormat(message = "좋아요 상태가 변경되었습니다.", status = 200)
+    public ResponseEntity<ApiResponse<LikeToggleResponseDto>> toggleLike(@PathVariable Long feedId,
+                                                                         @AuthenticationPrincipal UserDetails userDetails) {
+        log.info("좋아요 토글 요청 - feedId: {}", feedId);
+        
+        // 사용자 ID 추출
+        Long userId = getUserIdFromUserDetails(userDetails);
+        if (userId == null) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("사용자 정보를 찾을 수 없습니다."));
+        }
+        
+        LikeToggleResponseDto result = feedLikeService.toggleLike(feedId, userId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/{feedId}/likes")
+    @ApiResponseFormat(message = "좋아요 사용자 목록입니다.", status = 200)
+    public ResponseEntity<ApiResponse<PaginatedResponse<LikeUserResponseDto>>> getLikedUsers(
+            @PathVariable Long feedId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        log.info("좋아요 사용자 목록 조회 요청 - feedId: {}, page: {}, size: {}", feedId, page, size);
+        PaginatedResponse<LikeUserResponseDto> result = feedLikeService.getLikedUsers(feedId, page, size);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/my-likes")
+    @ApiResponseFormat(message = "내가 좋아요한 피드 목록입니다.", status = 200)
+    public ResponseEntity<ApiResponse<MyLikedFeedsResponseDto>> getMyLikedFeeds(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        log.info("내 좋아요 피드 목록 조회 요청 - page: {}, size: {}", page, size);
+        
+        // 사용자 ID 추출
+        Long userId = getUserIdFromUserDetails(userDetails);
+        if (userId == null) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("사용자 정보를 찾을 수 없습니다."));
+        }
+        
+        MyLikedFeedsResponseDto result = feedLikeService.getMyLikedFeeds(userId, page, size);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+    
+    @GetMapping("/my-likes/ids")
+    @ApiResponseFormat(message = "내가 좋아요한 피드 ID 목록입니다.", status = 200)
+    public ResponseEntity<ApiResponse<List<Long>>> getMyLikedFeedIds(@AuthenticationPrincipal UserDetails userDetails) {
+        log.info("내 좋아요 피드 ID 목록 조회 요청");
+        
+        // 사용자 ID 추출
+        Long userId = getUserIdFromUserDetails(userDetails);
+        if (userId == null) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.error("사용자 정보를 찾을 수 없습니다."));
+        }
+        
+        List<Long> result = feedLikeService.getMyLikedFeedIds(userId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+    
+    /**
+     * UserDetails에서 사용자 ID를 추출하는 헬퍼 메서드
+     *
+     * @param userDetails JWT 토큰에서 추출된 사용자 정보
+     * @return 사용자 ID
+     */
+    private Long getUserIdFromUserDetails(UserDetails userDetails) {
+        if (userDetails == null) {
+            log.warn("UserDetails가 null입니다.");
+            return null;
+        }
+
+        String loginId = userDetails.getUsername();
+        log.debug("UserDetails에서 사용자 정보 추출 완료");
+
+        Optional<User> userOptional = userRepository.findByLoginId(loginId);
+        if (userOptional.isEmpty()) {
+            log.warn("login_id로 사용자를 찾을 수 없습니다");
+            return null;
+        }
+
+        User user = userOptional.get();
+        log.debug("사용자 ID 추출 완료: {}", user.getId());
+        return user.getId();
+    }
+}

--- a/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
+++ b/src/main/java/com/cMall/feedShop/feed/presentation/FeedLikeController.java
@@ -108,18 +108,26 @@ public class FeedLikeController {
             return null;
         }
 
-        String email = userDetails.getUsername(); // JWT 토큰의 subject는 email
-        log.info("UserDetails에서 추출한 email: {}", email);
+        String username = userDetails.getUsername(); // JWT 토큰의 subject
+        log.info("UserDetails에서 추출한 username: {}", username);
 
-        // JWT 토큰의 subject가 email이므로 findByEmail 사용
-        Optional<User> userOptional = userRepository.findByEmail(email);
+        // 1. 먼저 email로 시도
+        Optional<User> userOptional = userRepository.findByEmail(username);
         if (userOptional.isPresent()) {
             User user = userOptional.get();
-            log.info("사용자 ID 추출 완료: {} (email: {})", user.getId(), email);
+            log.info("email로 사용자 찾음 - ID: {} (email: {})", user.getId(), username);
             return user.getId();
         }
 
-        log.warn("email '{}'로 사용자를 찾을 수 없습니다", email);
+        // 2. email로 찾지 못하면 loginId로 시도
+        userOptional = userRepository.findByLoginId(username);
+        if (userOptional.isPresent()) {
+            User user = userOptional.get();
+            log.info("loginId로 사용자 찾음 - ID: {} (loginId: {})", user.getId(), username);
+            return user.getId();
+        }
+
+        log.warn("username '{}'로 사용자를 찾을 수 없습니다 (email, loginId 모두 시도)", username);
         return null;
     }
 }

--- a/src/test/java/com/cMall/feedShop/feed/application/service/FeedLikeServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/feed/application/service/FeedLikeServiceTest.java
@@ -1,0 +1,324 @@
+package com.cMall.feedShop.feed.application.service;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+import com.cMall.feedShop.feed.application.dto.response.LikeToggleResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.LikeUserResponseDto;
+import com.cMall.feedShop.feed.application.dto.response.MyLikedFeedsResponseDto;
+import com.cMall.feedShop.feed.application.exception.FeedNotFoundException;
+import com.cMall.feedShop.feed.domain.Feed;
+import com.cMall.feedShop.feed.domain.FeedLike;
+import com.cMall.feedShop.feed.domain.repository.FeedLikeRepository;
+import com.cMall.feedShop.feed.domain.repository.FeedRepository;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.model.UserProfile;
+import com.cMall.feedShop.user.domain.enums.UserRole;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+import com.cMall.feedShop.order.domain.model.OrderItem;
+import com.cMall.feedShop.common.dto.PaginatedResponse;
+import com.cMall.feedShop.feed.domain.FeedType;
+
+@ExtendWith(MockitoExtension.class)
+class FeedLikeServiceTest {
+
+    @Mock
+    private FeedLikeRepository feedLikeRepository;
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private FeedLikeService feedLikeService;
+
+    private User user;
+    private Feed feed;
+    private FeedLike feedLike;
+    private UserProfile userProfile;
+
+    @BeforeEach
+    void setUp() {
+        userProfile = UserProfile.builder()
+                .nickname("테스트유저")
+                .build();
+
+        // User를 Mock으로 생성 (stub 없이)
+        user = mock(User.class);
+
+        // Feed를 Mock으로 생성 (stub 없이)
+        feed = mock(Feed.class);
+        
+        feedLike = FeedLike.builder()
+                .feed(feed)
+                .user(user)
+                .build();
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 좋아요 추가 성공")
+    void toggleLike_addLike_success() {
+        // given
+        when(feed.isDeleted()).thenReturn(false);
+        when(user.getId()).thenReturn(1L);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(feedRepository.findById(anyLong())).thenReturn(Optional.of(feed));
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(anyLong(), anyLong())).thenReturn(false);
+        when(feedLikeRepository.save(any(FeedLike.class))).thenReturn(feedLike);
+
+        // when
+        LikeToggleResponseDto result = feedLikeService.toggleLike(1L, 1L);
+
+        // then
+        assertThat(result.isLiked()).isTrue();
+        assertThat(result.getLikeCount()).isEqualTo(0);
+        verify(feed).incrementLikeCount();
+        verify(feedLikeRepository).save(any(FeedLike.class));
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 좋아요 취소 성공")
+    void toggleLike_removeLike_success() {
+        // given
+        when(feed.isDeleted()).thenReturn(false);
+        when(feed.getLikeCount()).thenReturn(1);
+        when(user.getId()).thenReturn(1L);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(feedRepository.findById(anyLong())).thenReturn(Optional.of(feed));
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(anyLong(), anyLong())).thenReturn(true);
+
+        // when
+        LikeToggleResponseDto result = feedLikeService.toggleLike(1L, 1L);
+
+        // then
+        assertThat(result.isLiked()).isFalse();
+        assertThat(result.getLikeCount()).isEqualTo(1);
+        verify(feed).decrementLikeCount();
+        verify(feedLikeRepository).deleteByFeed_IdAndUser_Id(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 사용자가 존재하지 않는 경우")
+    void toggleLike_userNotFound_throwsException() {
+        // given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.toggleLike(1L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 피드가 존재하지 않는 경우")
+    void toggleLike_feedNotFound_throwsException() {
+        // given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(feedRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.toggleLike(1L, 1L))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 삭제된 피드인 경우")
+    void toggleLike_deletedFeed_throwsException() {
+        // given
+        when(feed.isDeleted()).thenReturn(true);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(feedRepository.findById(anyLong())).thenReturn(Optional.of(feed));
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.toggleLike(1L, 1L))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - userId가 null인 경우")
+    void toggleLike_nullUserId_throwsException() {
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.toggleLike(1L, null))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("좋아요 사용자 목록 조회 - 성공")
+    void getLikedUsers_success() {
+        // given
+        when(feed.isDeleted()).thenReturn(false);
+        when(feedRepository.findById(anyLong())).thenReturn(Optional.of(feed));
+        
+        Page<FeedLike> feedLikePage = new PageImpl<>(List.of(feedLike));
+        when(feedLikeRepository.findByFeedIdWithUser(anyLong(), any(Pageable.class))).thenReturn(feedLikePage);
+
+        // when
+        PaginatedResponse<LikeUserResponseDto> result = feedLikeService.getLikedUsers(1L, 0, 20);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(feedLikeRepository).findByFeedIdWithUser(anyLong(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("좋아요 사용자 목록 조회 - 피드가 존재하지 않는 경우")
+    void getLikedUsers_feedNotFound_throwsException() {
+        // given
+        when(feedRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.getLikedUsers(1L, 0, 20))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("좋아요 사용자 목록 조회 - 삭제된 피드인 경우")
+    void getLikedUsers_deletedFeed_throwsException() {
+        // given
+        when(feed.isDeleted()).thenReturn(true);
+        when(feedRepository.findById(anyLong())).thenReturn(Optional.of(feed));
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.getLikedUsers(1L, 0, 20))
+                .isInstanceOf(FeedNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("내가 좋아요한 피드 목록 조회 - 성공")
+    void getMyLikedFeeds_success() {
+        // given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        
+        // Feed mock 설정
+        when(feed.getId()).thenReturn(1L);
+        when(feed.getTitle()).thenReturn("테스트 피드");
+        when(feed.getContent()).thenReturn("테스트 내용");
+        when(feed.getFeedType()).thenReturn(FeedType.DAILY);
+        when(feed.getLikeCount()).thenReturn(5);
+        when(feed.getCommentCount()).thenReturn(3);
+        when(feed.getUser()).thenReturn(user);
+        
+        // UserProfile mock 설정
+        when(user.getUserProfile()).thenReturn(userProfile);
+        
+        Page<FeedLike> feedLikePage = new PageImpl<>(List.of(feedLike));
+        when(feedLikeRepository.findByUserIdWithFeed(anyLong(), any(Pageable.class))).thenReturn(feedLikePage);
+
+        // when
+        MyLikedFeedsResponseDto result = feedLikeService.getMyLikedFeeds(1L, 0, 20);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getFeedId()).isEqualTo(1L);
+        assertThat(result.getContent().get(0).getTitle()).isEqualTo("테스트 피드");
+        verify(feedLikeRepository).findByUserIdWithFeed(anyLong(), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("내가 좋아요한 피드 목록 조회 - 사용자가 존재하지 않는 경우")
+    void getMyLikedFeeds_userNotFound_throwsException() {
+        // given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> feedLikeService.getMyLikedFeeds(1L, 0, 20))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("내가 좋아요한 피드 ID 목록 조회 - 성공")
+    void getMyLikedFeedIds_success() {
+        // given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(feedLikeRepository.findFeedIdsByUserId(anyLong())).thenReturn(List.of(1L, 2L, 3L));
+
+        // when
+        List<Long> result = feedLikeService.getMyLikedFeedIds(1L);
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly(1L, 2L, 3L);
+    }
+
+    @Test
+    @DisplayName("내가 좋아요한 피드 ID 목록 조회 - 사용자가 존재하지 않는 경우")
+    void getMyLikedFeedIds_userNotFound_returnsEmptyList() {
+        // given
+        when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // when
+        List<Long> result = feedLikeService.getMyLikedFeedIds(1L);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("사용자별 좋아요 상태 확인 - 좋아요한 경우")
+    void isLikedByUser_liked_returnsTrue() {
+        // given
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(anyLong(), anyLong())).thenReturn(true);
+
+        // when
+        boolean result = feedLikeService.isLikedByUser(1L, 1L);
+
+        // then
+        assertThat(result).isTrue();
+        verify(feedLikeRepository).existsByFeed_IdAndUser_Id(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("사용자별 좋아요 상태 확인 - 좋아요하지 않은 경우")
+    void isLikedByUser_notLiked_returnsFalse() {
+        // given
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(anyLong(), anyLong())).thenReturn(false);
+
+        // when
+        boolean result = feedLikeService.isLikedByUser(1L, 1L);
+
+        // then
+        assertThat(result).isFalse();
+        verify(feedLikeRepository).existsByFeed_IdAndUser_Id(1L, 1L);
+    }
+
+    @Test
+    @DisplayName("사용자별 좋아요 상태 확인 - 예외 발생 시 false 반환")
+    void isLikedByUser_exception_returnsFalse() {
+        // given
+        when(feedLikeRepository.existsByFeed_IdAndUser_Id(anyLong(), anyLong()))
+                .thenThrow(new RuntimeException("Database error"));
+
+        // when
+        boolean result = feedLikeService.isLikedByUser(1L, 1L);
+
+        // then
+        assertThat(result).isFalse();
+        verify(feedLikeRepository).existsByFeed_IdAndUser_Id(1L, 1L);
+    }
+}


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
로그인한 사용자가 좋아요한 피드를 모아서 조회할 수 있는 새로운 API 엔드포인트를 추가했습니다.

**Type**
- [X] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- **새로운 API 엔드포인트**
  - `GET /api/feeds/my-likes?page=0&size=20`
- **페이징 지원**
  - 페이지네이션 기반 대용량 데이터 처리
- **JWT 인증**
  - 로그인한 사용자만 접근 가능
- **상세 정보 제공**
  - 피드 정보, 작성자 정보, 좋아요한 시각 포함 응답 데이터 제공

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
- 사용자가 자신이 좋아요한 피드를 한 곳에서 모아볼 수 있는 기능 필요
- 마이페이지 내 개인화된 콘텐츠 관리 기능 강화
- 대용량 데이터 처리 및 효율적인 조회를 위한 페이징 필요
- 인증 기반 접근 제어를 통해 보안 강화

---

## 🔧 How (구현 방법)
### 주요 변경사항
- **Repository Layer**
  - JPA Query 활용, 효율적인 페이징 및 JOIN 처리
- **Service Layer**
  - `FeedLikeService` → 비즈니스 로직 분리 및 트랜잭션 관리
- **Controller Layer**
  - REST API 엔드포인트 구현 및 JWT 인증 처리
- **DTO Pattern**
  - `MyLikedFeedItemDto`, `MyLikedFeedsResponseDto` 작성
  - 응답 데이터 구조화 및 계층 분리
- **Unit Testing**
  - `FeedLikeServiceTest.java` 작성 (총 16개 단위 테스트)

### 기술적 접근
- **JWT 인증 로직**
  - JWT 토큰의 subject가 `email` 또는 `loginId`일 수 있어,  
    `findByEmail()` → `findByLoginId()` 순서로 유연하게 조회
- **성능 고려**
  - 페이징을 통한 대용량 데이터 처리
  - JOIN 쿼리 최적화로 N+1 문제 방지
---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
- **백엔드 테스트**
  - `FeedLikeServiceTest.java`: 16개 단위 테스트 작성
  - 성공 케이스: 정상적인 좋아요 피드 목록 조회
  - 예외 케이스: 사용자 없음, 페이징 처리 검증
  - Mockito 기반 의존성 모킹

### 확인 사항
- [X] 기능 정상 동작 확인
- [X] 기존 기능 영향 없음
- [X] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: FD-811
- 지라 백로그: MYCE-243
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
- **JWT 인증**
  - subject 값이 `email` 또는 `loginId`일 수 있으므로 유연한 조회 로직 적용
- **성능**
  - 페이징을 통한 대용량 데이터 처리
  - JOIN 최적화로 N+1 문제 방지
- **향후 개선 사항**
  - 캐싱 적용 고려
  - 좋아요 취소 시 실시간 목록 업데이트 기능 추가 예정
---

## ✅ Checklist
- [X] 코드 리뷰 준비 완료
- [X] 테스트 완료
- [X] 불필요한 로그 제거
