### PR TITLE
Fix: Cloud Run 배포 권한 오류 해결

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -74,6 +74,7 @@ jobs:
             --platform managed \
             --region $REGION \
             --allow-unauthenticated \
+            --service-account=feedshop-prod-api-deployer@onyx-oxygen-462722-c0.iam.gserviceaccount.com
             --memory 2Gi \
             --cpu 2 \
             --concurrency 1000 \


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
CI/CD Cloud Run 배포 권한 오류 수정


**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
`gcloud run deploy` 명령어에 `--service-account` 플래그를 추가하여 배포 시 사용할 서비스 계정을 명시적으로 지정했습니다.

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
기존 CI/CD 배포 과정에서 'iam.serviceaccounts.actAs' 권한 오류로 인해 Cloud Run 배포가 실패했습니다. 이는 배포를 수행하는 GitHub Actions 서비스 계정(`feedshop-prod-api-deployer`)이 Cloud Run 서비스의 런타임 ID로 사용되는 기본 컴퓨트 서비스 계정에 대한 권한이 없어서 발생했습니다. 이 문제를 해결하여 자동 배포 파이프라인을 정상화하기 위해 수정이 필요했습니다.

---

## 🔧 How (구현 방법)
### 주요 변경사항
- `on: push` 이벤트에 의해 트리거되는 `deploy` 잡의 `Deploy to Cloud Run` 스텝에 `--service-account` 플래그를 추가했습니다.


### 기술적 접근
- `gcloud run deploy` 명령어에 `--service-account=feedshop-prod-api-deployer@onyx-oxygen-462722-c0.iam.gserviceaccount.com`를 직접 명시하여, Cloud Run 서비스가 배포를 수행하는 서비스 계정과 동일한 계정을 런타임 ID로 사용하도록 했습니다.
- 이 방식은 다른 서비스 계정에 대한 권한 설정 없이도 배포 계정 자신이 자신을 대신할 수 있으므로 권한 오류를 효과적으로 해결합니다.
---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
`main` 브랜치에 푸시하여 CI/CD 워크플로우를 직접 실행하고 배포 성공 여부를 확인했습니다.

### 확인 사항
- [ ] 기능 정상 동작 확인
- [ ] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
이번 변경으로 CI/CD 파이프라인이 안정적으로 작동할 것으로 예상됩니다. 추후 Cloud Run 서비스의 권한을 더 세분화해야 할 경우, 별도의 런타임 서비스 계정을 생성하고 해당 계정에 필요한 권한을 부여한 뒤 이 PR에서 수정한 플래그 값을 변경해야 합니다.

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [ ] 테스트 완료
- [ ] 불필요한 로그 제거
