### PR TITLE
MYCE-15 fix: 회원가입 오류 수정

### DIFF
--- a/src/main/java/com/cMall/feedShop/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserServiceImpl.java
@@ -96,10 +96,10 @@ public class UserServiceImpl implements UserService{
         updateVerificationToken(user);
 
         UserProfile userProfile = UserProfile.builder()
-
                 .user(user)
                 .name(request.getName())
                 .nickname(request.getNickname())
+                .phone(request.getPhone())
                 .build();
 
         user.setUserProfile(userProfile);


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
회원가입 시 UserProfile 생성 시 phone 필드 누락으로 인한 DataIntegrityViolationException 수정


**Type**
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
UserServiceImpl.signUp() 메서드에서 UserProfile 생성 시 phone 필드를 설정하도록 수정
UserProfile.builder()에 .phone(request.getPhone()) 추가


### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
회원가입 시 user_profiles 테이블의 phone 컬럼에 null 값이 들어가려고 해서 DataIntegrityViolationException 발생
UserProfile 엔티티의 phone 필드는 nullable = false로 설정되어 있어서 반드시 값이 필요함
UserSignUpRequest에는 phone 필드가 있지만 UserProfile 생성 시 전달하지 않아서 발생한 문제

---

## 🔧 How (구현 방법)
### 주요 변경사항
UserServiceImpl.java의 signUp() 메서드에서 UserProfile.builder()에 .phone(request.getPhone()) 추가
### 기술적 접근
기존 코드에서 누락된 필드 매핑을 추가하여 데이터 무결성 보장
JPA 엔티티의 제약조건과 실제 데이터 설정을 일치시킴

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
회원가입 API 호출하여 정상 동작 확인
데이터베이스에 phone 필드가 정상적으로 저장되는지 확인

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #29
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-15](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
UserProfile 엔티티의 phone 필드는 nullable = false로 설정되어 있어 반드시 값이 필요함
UserSignUpRequest의 phone 필드는 @NotBlank 검증이 있어서 클라이언트에서 반드시 전달됨
이 수정으로 회원가입 프로세스가 정상적으로 완료될 수 있음

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
