### PR TITLE
Update cd-deploy.yml

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -91,7 +91,7 @@ jobs:
             --set-secrets="MAILGUN_EMAIL=mailgun_email:latest" \
             --set-secrets="GCS_ID=gcs_id:latest" \
             --set-secrets="GCS_BUCKET=gcs_prod_bucket:latest" \
-            --set-secrets="CDN_BASE_URL=${{ secrets.CDN_BASE_URL }}" \
+            --set-env-vars="CDN_BASE_URL=${{ secrets.CDN_BASE_URL }}" \
             --set-secrets="RECAPTCHA_SECRET_KEY=recaptcha_secret_key:latest" \
             --timeout 900s
 


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
CDN_BASE_URL 환경 변수 설정 방식을 수정하여 배포 오류 해결



**Type**
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
gcloud run deploy 명령어에서 CDN_BASE_URL 환경 변수를 --set-secrets 대신 **--set-env-vars**로 설정하도록 변경했습니다.
### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
기존에 CDN_BASE_URL 환경 변수가 gcloud run deploy 명령의 --set-secrets 구문으로 잘못 설정되어 있었습니다. secrets 구문은 Secret Manager의 키를 참조할 때 사용하는데, CDN_BASE_URL은 Secret Manager가 아닌 GitHub Actions의 시크릿에 저장된 값입니다. 이로 인해 유효하지 않은 키 참조 오류가 발생하여 Cloud Run 배포가 실패했습니다. 이번 PR을 통해 올바른 환경 변수 설정 방식으로 수정하여 배포 오류를 해결합니다.


---

## 🔧 How (구현 방법)
### 주요 변경사항


### 기술적 접근
- 

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

### 확인 사항
- [ ] 기능 정상 동작 확인
- [ ] 기존 기능 영향 없음
- [ ] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈:
- 지라 백로그: 
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

---

## ✅ Checklist
- [ ] 코드 리뷰 준비 완료
- [ ] 테스트 완료
- [ ] 불필요한 로그 제거
