### PR TITLE
MYCE-281:feat/reviewReport-리뷰 신고 기능 api 구현 (#651)

### DIFF
--- a/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
+++ b/src/main/java/com/cMall/feedShop/common/exception/ErrorCode.java
@@ -91,6 +91,8 @@ public enum ErrorCode {
     REVIEW_ALREADY_DELETED(409, "R005", "이미 삭제된 리뷰입니다."),
     REVIEW_DELETE_FORBIDDEN(403, "R006", "해당 리뷰를 삭제할 권한이 없습니다."),
     REVIEW_DELETION_FAILED(500, "R007", "리뷰 삭제 중 오류가 발생했습니다."),
+    DUPLICATE_REPORT(409, "R008", "이미 신고한 리뷰입니다."),
+    SELF_REPORT_NOT_ALLOWED(400, "R009", "자신이 작성한 리뷰는 신고할 수 없습니다."),
 
   
     // 이벤트 (현재 구현된 읽기 전용 API에서만 사용)

--- a/src/main/java/com/cMall/feedShop/config/DevSecurityConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/DevSecurityConfig.java
@@ -62,7 +62,7 @@ public class DevSecurityConfig {
                 "http://localhost:3000", // React 개발 서버 기본 포트
                 "http://127.0.0.1:3000" // localhost 대신 127.0.0.1을 사용할 수도 있으므로 추가
         ));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
         config.setAllowCredentials(true); // 자격 증명(쿠키, HTTP 인증 등) 허용
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/cMall/feedShop/config/WebConfig.java
+++ b/src/main/java/com/cMall/feedShop/config/WebConfig.java
@@ -1,6 +1,7 @@
 package com.cMall.feedShop.config;
 
 
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;

--- a/src/main/java/com/cMall/feedShop/review/application/dto/request/ReviewReportRequest.java
+++ b/src/main/java/com/cMall/feedShop/review/application/dto/request/ReviewReportRequest.java
@@ -1,0 +1,29 @@
+package com.cMall.feedShop.review.application.dto.request;
+
+import com.cMall.feedShop.review.domain.enums.ReportReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "리뷰 신고 요청")
+public class ReviewReportRequest {
+
+    @NotNull(message = "신고 사유는 필수입니다.")
+    @Schema(description = "신고 사유", example = "ABUSIVE_LANGUAGE")
+    private ReportReason reason;
+
+    @Size(max = 500, message = "신고 상세 설명은 500자 이하로 입력해주세요.")
+    @Schema(description = "신고 상세 설명 (선택사항)", example = "욕설이 포함된 리뷰입니다.")
+    private String description;
+
+    @Builder
+    public ReviewReportRequest(ReportReason reason, String description) {
+        this.reason = reason;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/application/dto/response/ReportedReviewResponse.java
+++ b/src/main/java/com/cMall/feedShop/review/application/dto/response/ReportedReviewResponse.java
@@ -1,0 +1,77 @@
+package com.cMall.feedShop.review.application.dto.response;
+
+import com.cMall.feedShop.review.domain.enums.ReportReason;
+import com.cMall.feedShop.review.domain.enums.ReviewStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "신고된 리뷰 정보 (관리자용)")
+public class ReportedReviewResponse {
+
+    @Schema(description = "리뷰 ID")
+    private Long reviewId;
+
+    @Schema(description = "리뷰 제목")
+    private String title;
+
+    @Schema(description = "리뷰 내용")
+    private String content;
+
+    @Schema(description = "작성자 ID")
+    private Long writerId;
+
+    @Schema(description = "작성자 이름")
+    private String writerName;
+
+    @Schema(description = "상품 ID")
+    private Long productId;
+
+    @Schema(description = "상품명")
+    private String productName;
+
+    @Schema(description = "리뷰 상태")
+    private ReviewStatus status;
+
+    @Schema(description = "총 신고 수")
+    private Long totalReportCount;
+
+    @Schema(description = "처리되지 않은 신고 수")
+    private Long unprocessedReportCount;
+
+    @Schema(description = "신고 목록")
+    private List<ReportInfo> reports;
+
+    @Schema(description = "리뷰 작성일")
+    private LocalDateTime reviewCreatedAt;
+
+    @Getter
+    @Builder
+    public static class ReportInfo {
+        @Schema(description = "신고 ID")
+        private Long reportId;
+
+        @Schema(description = "신고자 ID")
+        private Long reporterId;
+
+        @Schema(description = "신고자 이름")
+        private String reporterName;
+
+        @Schema(description = "신고 사유")
+        private ReportReason reason;
+
+        @Schema(description = "신고 상세 설명")
+        private String description;
+
+        @Schema(description = "처리 여부")
+        private Boolean isProcessed;
+
+        @Schema(description = "신고 일시")
+        private LocalDateTime createdAt;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/application/dto/response/ReviewReportResponse.java
+++ b/src/main/java/com/cMall/feedShop/review/application/dto/response/ReviewReportResponse.java
@@ -1,0 +1,35 @@
+package com.cMall.feedShop.review.application.dto.response;
+
+import com.cMall.feedShop.review.domain.enums.ReportReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@Schema(description = "리뷰 신고 응답")
+public class ReviewReportResponse {
+
+    @Schema(description = "신고 ID")
+    private Long reportId;
+
+    @Schema(description = "리뷰 ID")
+    private Long reviewId;
+
+    @Schema(description = "신고자 ID")
+    private Long reporterId;
+
+    @Schema(description = "신고 사유")
+    private ReportReason reason;
+
+    @Schema(description = "신고 상세 설명")
+    private String description;
+
+    @Schema(description = "처리 여부")
+    private Boolean isProcessed;
+
+    @Schema(description = "신고 일시")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/cMall/feedShop/review/application/service/ReviewReportService.java
+++ b/src/main/java/com/cMall/feedShop/review/application/service/ReviewReportService.java
@@ -159,20 +159,42 @@ public class ReviewReportService {
     }
 
     private ReportedReviewResponse mapToReportedReviewResponse(List<ReviewReport> reports) {
+        if (reports == null || reports.isEmpty()) {
+            throw new IllegalArgumentException("신고 목록이 비어있거나 존재하지 않습니다.");
+        }
+
         ReviewReport firstReport = reports.get(0);
         Review review = firstReport.getReview();
+        
+        if (review == null) {
+            throw new IllegalStateException("신고된 리뷰 정보가 존재하지 않습니다.");
+        }
+        
+        if (review.getUser() == null) {
+            throw new IllegalStateException("리뷰 작성자 정보가 존재하지 않습니다.");
+        }
+        
+        if (review.getProduct() == null) {
+            throw new IllegalStateException("리뷰 상품 정보가 존재하지 않습니다.");
+        }
 
         List<ReportedReviewResponse.ReportInfo> reportInfos = reports.stream()
-                .map(report -> ReportedReviewResponse.ReportInfo.builder()
-                        .reportId(report.getReportId())
-                        .reporterId(report.getReporter().getId())
-                        .reporterName(report.getReporter().getUserProfile() != null ? 
-                                report.getReporter().getUserProfile().getNickname() : "사용자")
-                        .reason(report.getReason())
-                        .description(report.getDescription())
-                        .isProcessed(report.isProcessed())
-                        .createdAt(report.getCreatedAt())
-                        .build())
+                .map(report -> {
+                    if (report.getReporter() == null) {
+                        throw new IllegalStateException("신고자 정보가 존재하지 않습니다.");
+                    }
+                    
+                    return ReportedReviewResponse.ReportInfo.builder()
+                            .reportId(report.getReportId())
+                            .reporterId(report.getReporter().getId())
+                            .reporterName(report.getReporter().getUserProfile() != null ? 
+                                    report.getReporter().getUserProfile().getNickname() : "사용자")
+                            .reason(report.getReason())
+                            .description(report.getDescription())
+                            .isProcessed(report.isProcessed())
+                            .createdAt(report.getCreatedAt())
+                            .build();
+                })
                 .toList();
 
         return ReportedReviewResponse.builder()

--- a/src/main/java/com/cMall/feedShop/review/application/service/ReviewReportService.java
+++ b/src/main/java/com/cMall/feedShop/review/application/service/ReviewReportService.java
@@ -1,0 +1,183 @@
+package com.cMall.feedShop.review.application.service;
+
+import com.cMall.feedShop.common.dto.PaginatedResponse;
+import com.cMall.feedShop.review.application.dto.request.ReviewReportRequest;
+import com.cMall.feedShop.review.application.dto.response.ReportedReviewResponse;
+import com.cMall.feedShop.review.application.dto.response.ReviewReportResponse;
+import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.ReviewReport;
+import com.cMall.feedShop.review.domain.enums.ReviewStatus;
+import com.cMall.feedShop.review.domain.exception.DuplicateReportException;
+import com.cMall.feedShop.review.domain.exception.ReviewNotFoundException;
+import com.cMall.feedShop.review.domain.repository.ReviewRepository;
+import com.cMall.feedShop.review.domain.repository.ReviewReportRepository;
+import com.cMall.feedShop.user.domain.exception.UserNotFoundException;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class ReviewReportService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewReportRepository reviewReportRepository;
+    private final UserRepository userRepository;
+
+    @Value("${review.report.auto-hide-threshold:5}")
+    private int autoHideThreshold;
+
+    public ReviewReportResponse reportReview(Long reviewId, String reporterLoginId, ReviewReportRequest request) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException("신고할 리뷰를 찾을 수 없습니다."));
+
+        log.info("DEBUG - userRepository.findByLoginId 호출: {}", reporterLoginId);
+        User reporter = userRepository.findByLoginId(reporterLoginId)
+                .orElseThrow(() -> {
+                    log.error("DEBUG - 사용자를 찾을 수 없음: {}", reporterLoginId);
+                    return new UserNotFoundException("신고자 정보를 찾을 수 없습니다.");
+                });
+        log.info("DEBUG - 사용자 조회 성공: userId={}, loginId={}", reporter.getId(), reporter.getLoginId());
+
+        if (reviewReportRepository.existsByReviewAndReporter(review, reporter)) {
+            throw new DuplicateReportException("이미 신고한 리뷰입니다.");
+        }
+
+        ReviewReport reviewReport = ReviewReport.builder()
+                .review(review)
+                .reporter(reporter)
+                .reason(request.getReason())
+                .description(request.getDescription())
+                .build();
+
+        ReviewReport savedReport = reviewReportRepository.save(reviewReport);
+
+        updateReviewReportCount(review);
+        checkAutoHideThreshold(review);
+
+        log.info("리뷰 신고 완료: reviewId={}, reporterLoginId={}, reason={}", 
+                reviewId, reporterLoginId, request.getReason());
+
+        return mapToReportResponse(savedReport);
+    }
+
+    @Transactional(readOnly = true)
+    public PaginatedResponse<ReportedReviewResponse> getReportedReviews(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ReviewReport> reportPage = reviewReportRepository.findUnprocessedReports(pageable);
+
+        List<ReportedReviewResponse> responses = reportPage.getContent().stream()
+                .collect(Collectors.groupingBy(report -> report.getReview().getReviewId()))
+                .values().stream()
+                .map(this::mapToReportedReviewResponse)
+                .collect(Collectors.toList());
+
+        return PaginatedResponse.<ReportedReviewResponse>builder()
+                .content(responses)
+                .page(page)
+                .size(size)
+                .totalElements((long) responses.size())
+                .totalPages((int) Math.ceil((double) responses.size() / size))
+                .build();
+    }
+
+    public void hideReview(Long reviewId, String adminLoginId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException("숨김 처리할 리뷰를 찾을 수 없습니다."));
+
+        review.markAsHidden();
+        review.getImages().forEach(image -> image.delete());
+        
+        List<ReviewReport> reports = reviewReportRepository.findByReview(review);
+        reports.forEach(ReviewReport::markAsProcessed);
+        
+        reviewRepository.save(review);
+
+        log.info("리뷰 숨김 처리 완료: reviewId={}, adminLoginId={}", reviewId, adminLoginId);
+    }
+
+    public void showReview(Long reviewId, String adminLoginId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new ReviewNotFoundException("숨김 해제할 리뷰를 찾을 수 없습니다."));
+
+        review.markAsActive();
+        reviewRepository.save(review);
+
+        log.info("리뷰 숨김 해제 완료: reviewId={}, adminLoginId={}", reviewId, adminLoginId);
+    }
+
+    private void updateReviewReportCount(Review review) {
+        review.increaseReportCount();
+        reviewRepository.save(review);
+    }
+
+    private void checkAutoHideThreshold(Review review) {
+        long reportCount = reviewReportRepository.countByReview(review);
+        if (reportCount >= autoHideThreshold && review.getStatus() == ReviewStatus.ACTIVE) {
+            review.markAsHidden();
+            reviewRepository.save(review);
+            
+            log.warn("리뷰 자동 숨김 처리: reviewId={}, reportCount={}", review.getReviewId(), reportCount);
+        }
+    }
+
+    private ReviewReportResponse mapToReportResponse(ReviewReport report) {
+        return ReviewReportResponse.builder()
+                .reportId(report.getReportId())
+                .reviewId(report.getReview().getReviewId())
+                .reporterId(report.getReporter().getId())
+                .reason(report.getReason())
+                .description(report.getDescription())
+                .isProcessed(report.isProcessed())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+
+    private ReportedReviewResponse mapToReportedReviewResponse(List<ReviewReport> reports) {
+        ReviewReport firstReport = reports.get(0);
+        Review review = firstReport.getReview();
+
+        List<ReportedReviewResponse.ReportInfo> reportInfos = reports.stream()
+                .map(report -> ReportedReviewResponse.ReportInfo.builder()
+                        .reportId(report.getReportId())
+                        .reporterId(report.getReporter().getId())
+                        .reporterName(report.getReporter().getUserProfile() != null ? 
+                                report.getReporter().getUserProfile().getNickname() : "사용자")
+                        .reason(report.getReason())
+                        .description(report.getDescription())
+                        .isProcessed(report.isProcessed())
+                        .createdAt(report.getCreatedAt())
+                        .build())
+                .toList();
+
+        return ReportedReviewResponse.builder()
+                .reviewId(review.getReviewId())
+                .title(review.getTitle())
+                .content(review.getContent())
+                .writerId(review.getUser().getId())
+                .writerName(review.getUser().getUserProfile() != null ? 
+                        review.getUser().getUserProfile().getNickname() : "사용자")
+                .productId(review.getProduct().getProductId())
+                .productName(review.getProduct().getName())
+                .status(review.getStatus())
+                .totalReportCount((long) reports.size())
+                .unprocessedReportCount(reports.stream()
+                        .filter(report -> !report.isProcessed())
+                        .count())
+                .reports(reportInfos)
+                .reviewCreatedAt(review.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/domain/Review.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/Review.java
@@ -302,4 +302,36 @@ public class Review extends BaseTimeEntity {
         this.status = ReviewStatus.DELETED;
         log.info("리뷰가 삭제 상태로 변경됨: reviewId={}", this.reviewId);
     }
+
+    /**
+     * 신고 수 증가
+     */
+    public void increaseReportCount() {
+        this.reportCount++;
+    }
+
+    /**
+     * 리뷰 숨김 처리
+     */
+    public void markAsHidden() {
+        this.status = ReviewStatus.HIDDEN;
+        this.isBlinded = true;
+        log.info("리뷰가 숨김 처리됨: reviewId={}", this.reviewId);
+    }
+
+    /**
+     * 리뷰 숨김 해제
+     */
+    public void markAsActive() {
+        this.status = ReviewStatus.ACTIVE;
+        this.isBlinded = false;
+        log.info("리뷰 숨김이 해제됨: reviewId={}", this.reviewId);
+    }
+
+    /**
+     * 리뷰가 숨김 상태인지 확인
+     */
+    public boolean isHidden() {
+        return this.status == ReviewStatus.HIDDEN || this.isBlinded;
+    }
 }

--- a/src/main/java/com/cMall/feedShop/review/domain/ReviewReport.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/ReviewReport.java
@@ -1,0 +1,74 @@
+package com.cMall.feedShop.review.domain;
+
+import com.cMall.feedShop.common.BaseTimeEntity;
+import com.cMall.feedShop.review.domain.enums.ReportReason;
+import com.cMall.feedShop.user.domain.model.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "review_reports",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"review_id", "reporter_id"}))
+@Getter
+@NoArgsConstructor
+public class ReviewReport extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reason", nullable = false)
+    private ReportReason reason;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "is_processed", nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private Boolean isProcessed = false;
+
+    @Builder
+    public ReviewReport(Review review, User reporter, ReportReason reason, String description) {
+        validateInputs(review, reporter, reason);
+        
+        this.review = review;
+        this.reporter = reporter;
+        this.reason = reason;
+        this.description = description;
+        this.isProcessed = false;
+    }
+
+    private void validateInputs(Review review, User reporter, ReportReason reason) {
+        if (review == null) {
+            throw new IllegalArgumentException("신고할 리뷰는 필수입니다.");
+        }
+        if (reporter == null) {
+            throw new IllegalArgumentException("신고자 정보는 필수입니다.");
+        }
+        if (reason == null) {
+            throw new IllegalArgumentException("신고 사유는 필수입니다.");
+        }
+        if (review.isOwnedBy(reporter.getId())) {
+            throw new IllegalArgumentException("자신이 작성한 리뷰는 신고할 수 없습니다.");
+        }
+    }
+
+    public void markAsProcessed() {
+        this.isProcessed = true;
+    }
+
+    public boolean isProcessed() {
+        return this.isProcessed;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/domain/enums/ReportReason.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/enums/ReportReason.java
@@ -1,0 +1,21 @@
+package com.cMall.feedShop.review.domain.enums;
+
+public enum ReportReason {
+    ABUSIVE_LANGUAGE("욕설 및 비방"),
+    SPAM("스팸 및 도배"),
+    INAPPROPRIATE_CONTENT("부적절한 내용"),
+    FALSE_INFORMATION("허위 정보"),
+    ADVERTISING("광고성 내용"),
+    COPYRIGHT_VIOLATION("저작권 침해"),
+    OTHER("기타");
+
+    private final String description;
+
+    ReportReason(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/domain/exception/DuplicateReportException.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/exception/DuplicateReportException.java
@@ -1,0 +1,14 @@
+package com.cMall.feedShop.review.domain.exception;
+
+import com.cMall.feedShop.common.exception.BusinessException;
+import com.cMall.feedShop.common.exception.ErrorCode;
+
+public class DuplicateReportException extends BusinessException {
+    public DuplicateReportException() {
+        super(ErrorCode.DUPLICATE_REPORT);
+    }
+    
+    public DuplicateReportException(String message) {
+        super(ErrorCode.DUPLICATE_REPORT, message);
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/domain/repository/ReviewReportRepository.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/repository/ReviewReportRepository.java
@@ -17,4 +17,7 @@ public interface ReviewReportRepository {
     Page<ReviewReport> findUnprocessedReports(Pageable pageable);
     long countByReview(Review review);
     void deleteById(Long reportId);
+    Page<Long> findDistinctReviewIdsWithUnprocessedReports(Pageable pageable);
+    long countDistinctReviewsWithUnprocessedReports();
+    List<ReviewReport> findUnprocessedReportsByReviewIds(List<Long> reviewIds);
 }

--- a/src/main/java/com/cMall/feedShop/review/domain/repository/ReviewReportRepository.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/repository/ReviewReportRepository.java
@@ -1,0 +1,20 @@
+package com.cMall.feedShop.review.domain.repository;
+
+import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.ReviewReport;
+import com.cMall.feedShop.user.domain.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewReportRepository {
+    ReviewReport save(ReviewReport reviewReport);
+    Optional<ReviewReport> findByReviewAndReporter(Review review, User reporter);
+    boolean existsByReviewAndReporter(Review review, User reporter);
+    List<ReviewReport> findByReview(Review review);
+    Page<ReviewReport> findUnprocessedReports(Pageable pageable);
+    long countByReview(Review review);
+    void deleteById(Long reportId);
+}

--- a/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportJpaRepository.java
+++ b/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportJpaRepository.java
@@ -32,4 +32,21 @@ public interface ReviewReportJpaRepository extends JpaRepository<ReviewReport, L
     @Query("SELECT COUNT(rr) FROM ReviewReport rr " +
            "WHERE rr.review = :review AND rr.isProcessed = false")
     long countUnprocessedByReview(@Param("review") Review review);
+
+    @Query("SELECT DISTINCT r.reviewId FROM ReviewReport rr " +
+           "JOIN rr.review r " +
+           "WHERE rr.isProcessed = false " +
+           "ORDER BY MIN(rr.createdAt) DESC")
+    Page<Long> findDistinctReviewIdsWithUnprocessedReports(Pageable pageable);
+
+    @Query("SELECT COUNT(DISTINCT rr.review.reviewId) FROM ReviewReport rr " +
+           "WHERE rr.isProcessed = false")
+    long countDistinctReviewsWithUnprocessedReports();
+
+    @Query("SELECT rr FROM ReviewReport rr " +
+           "JOIN FETCH rr.review r " +
+           "JOIN FETCH rr.reporter u " +
+           "WHERE r.reviewId IN :reviewIds AND rr.isProcessed = false " +
+           "ORDER BY rr.createdAt DESC")
+    List<ReviewReport> findUnprocessedReportsByReviewIds(@Param("reviewIds") List<Long> reviewIds);
 }

--- a/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportJpaRepository.java
+++ b/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportJpaRepository.java
@@ -1,0 +1,35 @@
+package com.cMall.feedShop.review.infrastructure.repository;
+
+import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.ReviewReport;
+import com.cMall.feedShop.user.domain.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReviewReportJpaRepository extends JpaRepository<ReviewReport, Long> {
+
+    Optional<ReviewReport> findByReviewAndReporter(Review review, User reporter);
+
+    boolean existsByReviewAndReporter(Review review, User reporter);
+
+    List<ReviewReport> findByReview(Review review);
+
+    @Query("SELECT rr FROM ReviewReport rr " +
+           "JOIN FETCH rr.review r " +
+           "JOIN FETCH rr.reporter u " +
+           "WHERE rr.isProcessed = false " +
+           "ORDER BY rr.createdAt DESC")
+    Page<ReviewReport> findByIsProcessedFalseOrderByCreatedAtDesc(Pageable pageable);
+
+    long countByReview(Review review);
+
+    @Query("SELECT COUNT(rr) FROM ReviewReport rr " +
+           "WHERE rr.review = :review AND rr.isProcessed = false")
+    long countUnprocessedByReview(@Param("review") Review review);
+}

--- a/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportRepositoryImpl.java
+++ b/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportRepositoryImpl.java
@@ -52,4 +52,19 @@ public class ReviewReportRepositoryImpl implements ReviewReportRepository {
     public void deleteById(Long reportId) {
         reviewReportJpaRepository.deleteById(reportId);
     }
+
+    @Override
+    public Page<Long> findDistinctReviewIdsWithUnprocessedReports(Pageable pageable) {
+        return reviewReportJpaRepository.findDistinctReviewIdsWithUnprocessedReports(pageable);
+    }
+
+    @Override
+    public long countDistinctReviewsWithUnprocessedReports() {
+        return reviewReportJpaRepository.countDistinctReviewsWithUnprocessedReports();
+    }
+
+    @Override
+    public List<ReviewReport> findUnprocessedReportsByReviewIds(List<Long> reviewIds) {
+        return reviewReportJpaRepository.findUnprocessedReportsByReviewIds(reviewIds);
+    }
 }

--- a/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportRepositoryImpl.java
+++ b/src/main/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.cMall.feedShop.review.infrastructure.repository;
+
+import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.ReviewReport;
+import com.cMall.feedShop.review.domain.repository.ReviewReportRepository;
+import com.cMall.feedShop.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewReportRepositoryImpl implements ReviewReportRepository {
+
+    private final ReviewReportJpaRepository reviewReportJpaRepository;
+
+    @Override
+    public ReviewReport save(ReviewReport reviewReport) {
+        return reviewReportJpaRepository.save(reviewReport);
+    }
+
+    @Override
+    public Optional<ReviewReport> findByReviewAndReporter(Review review, User reporter) {
+        return reviewReportJpaRepository.findByReviewAndReporter(review, reporter);
+    }
+
+    @Override
+    public boolean existsByReviewAndReporter(Review review, User reporter) {
+        return reviewReportJpaRepository.existsByReviewAndReporter(review, reporter);
+    }
+
+    @Override
+    public List<ReviewReport> findByReview(Review review) {
+        return reviewReportJpaRepository.findByReview(review);
+    }
+
+    @Override
+    public Page<ReviewReport> findUnprocessedReports(Pageable pageable) {
+        return reviewReportJpaRepository.findByIsProcessedFalseOrderByCreatedAtDesc(pageable);
+    }
+
+    @Override
+    public long countByReview(Review review) {
+        return reviewReportJpaRepository.countByReview(review);
+    }
+
+    @Override
+    public void deleteById(Long reportId) {
+        reviewReportJpaRepository.deleteById(reportId);
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/presentation/ReviewReportAdminController.java
+++ b/src/main/java/com/cMall/feedShop/review/presentation/ReviewReportAdminController.java
@@ -1,0 +1,89 @@
+package com.cMall.feedShop.review.presentation;
+
+import com.cMall.feedShop.common.aop.ApiResponseFormat;
+import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.common.dto.PaginatedResponse;
+import com.cMall.feedShop.review.application.dto.response.ReportedReviewResponse;
+import com.cMall.feedShop.review.application.service.ReviewReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/reviews")
+@RequiredArgsConstructor
+@Tag(name = "리뷰 신고 관리 API", description = "관리자용 리뷰 신고 관리 API")
+@SecurityRequirement(name = "bearerAuth")
+@PreAuthorize("hasRole('ADMIN')")
+public class ReviewReportAdminController {
+
+    private final ReviewReportService reviewReportService;
+
+    @GetMapping("/reports")
+    @ApiResponseFormat(message = "신고된 리뷰 목록을 성공적으로 조회했습니다.")
+    @Operation(summary = "신고된 리뷰 목록 조회", description = "관리자가 신고된 리뷰 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "신고된 리뷰 목록을 성공적으로 조회했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
+    })
+    public ApiResponse<PaginatedResponse<ReportedReviewResponse>> getReportedReviews(
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") int size) {
+
+        PaginatedResponse<ReportedReviewResponse> response = reviewReportService.getReportedReviews(page, size);
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("/{reviewId}/hide")
+    @ApiResponseFormat(message = "리뷰가 성공적으로 숨김 처리되었습니다.")
+    @Operation(summary = "리뷰 숨김 처리", description = "관리자가 신고된 리뷰를 숨김 처리합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "리뷰가 성공적으로 숨김 처리되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "숨김 처리할 리뷰를 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
+    })
+    public ApiResponse<Void> hideReview(
+            @Parameter(description = "리뷰 ID") @PathVariable Long reviewId,
+            Authentication authentication) {
+
+        String adminLoginId = getUserLoginIdFromAuthentication(authentication);
+
+        reviewReportService.hideReview(reviewId, adminLoginId);
+        return ApiResponse.success(null);
+    }
+
+    @PostMapping("/{reviewId}/show")
+    @ApiResponseFormat(message = "리뷰 숨김이 성공적으로 해제되었습니다.")
+    @Operation(summary = "리뷰 숨김 해제", description = "관리자가 숨김 처리된 리뷰를 다시 노출시킵니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "리뷰 숨김이 성공적으로 해제되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "숨김 해제할 리뷰를 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "관리자 권한이 필요합니다.")
+    })
+    public ApiResponse<Void> showReview(
+            @Parameter(description = "리뷰 ID") @PathVariable Long reviewId,
+            Authentication authentication) {
+
+        String adminLoginId = getUserLoginIdFromAuthentication(authentication);
+
+        reviewReportService.showReview(reviewId, adminLoginId);
+        return ApiResponse.success(null);
+    }
+
+    private String getUserLoginIdFromAuthentication(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof UserDetails) {
+            return ((UserDetails) principal).getUsername();
+        } else {
+            return authentication.getName();
+        }
+    }
+}

--- a/src/main/java/com/cMall/feedShop/review/presentation/ReviewReportController.java
+++ b/src/main/java/com/cMall/feedShop/review/presentation/ReviewReportController.java
@@ -1,0 +1,69 @@
+package com.cMall.feedShop.review.presentation;
+
+import com.cMall.feedShop.common.aop.ApiResponseFormat;
+import com.cMall.feedShop.common.dto.ApiResponse;
+import com.cMall.feedShop.review.application.dto.request.ReviewReportRequest;
+import com.cMall.feedShop.review.application.dto.response.ReviewReportResponse;
+import com.cMall.feedShop.review.application.service.ReviewReportService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user/reviews")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "리뷰 신고 API", description = "리뷰 신고 관련 API")
+public class ReviewReportController {
+
+    private final ReviewReportService reviewReportService;
+
+    @PostMapping("/{reviewId}/report")
+    @ApiResponseFormat(message = "리뷰 신고가 성공적으로 접수되었습니다.")
+    @Operation(summary = "리뷰 신고", description = "부적절한 리뷰를 신고합니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "리뷰 신고가 성공적으로 접수되었습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "자신이 작성한 리뷰는 신고할 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "신고할 리뷰를 찾을 수 없습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 신고한 리뷰입니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증이 필요합니다.")
+    })
+    public ApiResponse<ReviewReportResponse> reportReview(
+            @Parameter(description = "리뷰 ID") @PathVariable Long reviewId,
+            @Valid @RequestBody ReviewReportRequest request,
+            Authentication authentication) {
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new SecurityException("로그인이 필요합니다.");
+        }
+
+        String userLoginId = getUserLoginIdFromAuthentication(authentication);
+        ReviewReportResponse response = reviewReportService.reportReview(reviewId, userLoginId, request);
+        return ApiResponse.success(response);
+    }
+
+    private String getUserLoginIdFromAuthentication(Authentication authentication) {
+        Object principal = authentication.getPrincipal();
+        String username = null;
+
+        log.info("DEBUG - Authentication principal 타입: {}", principal.getClass().getSimpleName());
+        
+        if (principal instanceof UserDetails) {
+            username = ((UserDetails) principal).getUsername();
+            log.info("DEBUG - JWT 토큰에서 추출한 username (UserDetails): {}", username);
+        } else {
+            username = authentication.getName();
+            log.info("DEBUG - JWT 토큰에서 추출한 username (getName): {}", username);
+        }
+        
+        log.info("DEBUG - 최종 반환할 loginId: {}", username);
+        return username;
+    }
+}

--- a/src/test/java/com/cMall/feedShop/review/application/service/ReviewReportServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/review/application/service/ReviewReportServiceTest.java
@@ -1,0 +1,335 @@
+package com.cMall.feedShop.review.application.service;
+
+import com.cMall.feedShop.common.dto.PaginatedResponse;
+import com.cMall.feedShop.review.application.dto.request.ReviewReportRequest;
+import com.cMall.feedShop.review.application.dto.response.ReportedReviewResponse;
+import com.cMall.feedShop.review.application.dto.response.ReviewReportResponse;
+import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.ReviewReport;
+import com.cMall.feedShop.review.domain.enums.ReportReason;
+import com.cMall.feedShop.review.domain.enums.ReviewStatus;
+import com.cMall.feedShop.review.domain.exception.DuplicateReportException;
+import com.cMall.feedShop.review.domain.exception.ReviewNotFoundException;
+import com.cMall.feedShop.review.domain.repository.ReviewRepository;
+import com.cMall.feedShop.review.domain.repository.ReviewReportRepository;
+import com.cMall.feedShop.user.domain.exception.UserNotFoundException;
+import com.cMall.feedShop.user.domain.model.User;
+import com.cMall.feedShop.user.domain.model.UserProfile;
+import com.cMall.feedShop.user.domain.repository.UserRepository;
+import com.cMall.feedShop.product.domain.model.Product;
+import com.cMall.feedShop.store.domain.model.Store;
+import com.cMall.feedShop.product.domain.model.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReviewReportService 테스트")
+class ReviewReportServiceTest {
+
+    @InjectMocks
+    private ReviewReportService reviewReportService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReviewReportRepository reviewReportRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private Review review;
+    private User reporter;
+    private User reviewer;
+    private Product product;
+    private ReviewReport reviewReport;
+
+    @BeforeEach
+    void setUp() {
+        Store store = Store.builder()
+                .storeName("Test Store")
+                .sellerId(1L)
+                .build();
+        ReflectionTestUtils.setField(store, "storeId", 1L);
+
+        Category category = new Category();
+        ReflectionTestUtils.setField(category, "categoryId", 1L);
+
+        product = Product.builder()
+                .name("Test Product")
+                .price(BigDecimal.valueOf(10000))
+                .store(store)
+                .category(category)
+                .build();
+        ReflectionTestUtils.setField(product, "productId", 1L);
+
+        reviewer = User.builder()
+                .loginId("reviewer")
+                .password("password")
+                .email("reviewer@test.com")
+                .role(com.cMall.feedShop.user.domain.enums.UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(reviewer, "id", 1L);
+
+        UserProfile reviewerProfile = UserProfile.builder()
+                .nickname("리뷰어")
+                .build();
+        ReflectionTestUtils.setField(reviewer, "userProfile", reviewerProfile);
+
+        review = Review.builder()
+                .user(reviewer)
+                .product(product)
+                .title("Test Review")
+                .content("Test Content")
+                .rating(5)
+                .sizeFit(com.cMall.feedShop.review.domain.enums.SizeFit.NORMAL)
+                .cushion(com.cMall.feedShop.review.domain.enums.Cushion.SOFT)
+                .stability(com.cMall.feedShop.review.domain.enums.Stability.STABLE)
+                .build();
+        ReflectionTestUtils.setField(review, "reviewId", 1L);
+
+        reporter = User.builder()
+                .loginId("reporter")
+                .password("password")
+                .email("reporter@test.com")
+                .role(com.cMall.feedShop.user.domain.enums.UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(reporter, "id", 2L);
+
+        UserProfile reporterProfile = UserProfile.builder()
+                .nickname("신고자")
+                .build();
+        ReflectionTestUtils.setField(reporter, "userProfile", reporterProfile);
+
+        reviewReport = ReviewReport.builder()
+                .review(review)
+                .reporter(reporter)
+                .reason(ReportReason.ABUSIVE_LANGUAGE)
+                .description("욕설이 포함되어 있습니다.")
+                .build();
+        ReflectionTestUtils.setField(reviewReport, "reportId", 1L);
+        ReflectionTestUtils.setField(reviewReport, "createdAt", LocalDateTime.now());
+
+        ReflectionTestUtils.setField(reviewReportService, "autoHideThreshold", 5);
+    }
+
+    @Test
+    @DisplayName("리뷰 신고 성공")
+    void reportReview_Success() {
+        // given
+        Long reviewId = 1L;
+        String reporterLoginId = "reporter";
+        ReviewReportRequest request = new ReviewReportRequest(ReportReason.ABUSIVE_LANGUAGE, "욕설이 포함되어 있습니다.");
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(userRepository.findByLoginId(reporterLoginId)).willReturn(Optional.of(reporter));
+        given(reviewReportRepository.existsByReviewAndReporter(review, reporter)).willReturn(false);
+        given(reviewReportRepository.save(any(ReviewReport.class))).willReturn(reviewReport);
+        given(reviewReportRepository.countByReview(review)).willReturn(1L);
+
+        // when
+        ReviewReportResponse response = reviewReportService.reportReview(reviewId, reporterLoginId, request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getReportId()).isEqualTo(1L);
+        assertThat(response.getReviewId()).isEqualTo(reviewId);
+        assertThat(response.getReporterId()).isEqualTo(2L);
+        assertThat(response.getReason()).isEqualTo(ReportReason.ABUSIVE_LANGUAGE);
+        assertThat(response.getDescription()).isEqualTo("욕설이 포함되어 있습니다.");
+        assertThat(response.getIsProcessed()).isFalse();
+
+        verify(reviewRepository).save(review);
+        verify(reviewReportRepository).save(any(ReviewReport.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리뷰 신고 시 예외 발생")
+    void reportReview_ReviewNotFound_ThrowsException() {
+        // given
+        Long reviewId = 999L;
+        String reporterLoginId = "reporter";
+        ReviewReportRequest request = new ReviewReportRequest(ReportReason.ABUSIVE_LANGUAGE, "욕설이 포함되어 있습니다.");
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewReportService.reportReview(reviewId, reporterLoginId, request))
+                .isInstanceOf(ReviewNotFoundException.class)
+                .hasMessage("신고할 리뷰를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 신고 시 예외 발생")
+    void reportReview_UserNotFound_ThrowsException() {
+        // given
+        Long reviewId = 1L;
+        String reporterLoginId = "nonexistent";
+        ReviewReportRequest request = new ReviewReportRequest(ReportReason.ABUSIVE_LANGUAGE, "욕설이 포함되어 있습니다.");
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(userRepository.findByLoginId(reporterLoginId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewReportService.reportReview(reviewId, reporterLoginId, request))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessage("신고자 정보를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("중복 신고 시 예외 발생")
+    void reportReview_DuplicateReport_ThrowsException() {
+        // given
+        Long reviewId = 1L;
+        String reporterLoginId = "reporter";
+        ReviewReportRequest request = new ReviewReportRequest(ReportReason.ABUSIVE_LANGUAGE, "욕설이 포함되어 있습니다.");
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(userRepository.findByLoginId(reporterLoginId)).willReturn(Optional.of(reporter));
+        given(reviewReportRepository.existsByReviewAndReporter(review, reporter)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> reviewReportService.reportReview(reviewId, reporterLoginId, request))
+                .isInstanceOf(DuplicateReportException.class)
+                .hasMessage("이미 신고한 리뷰입니다.");
+    }
+
+    @Test
+    @DisplayName("신고 임계값 도달 시 리뷰 자동 숨김 처리")
+    void reportReview_AutoHideWhenThresholdReached() {
+        // given
+        Long reviewId = 1L;
+        String reporterLoginId = "reporter";
+        ReviewReportRequest request = new ReviewReportRequest(ReportReason.ABUSIVE_LANGUAGE, "욕설이 포함되어 있습니다.");
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(userRepository.findByLoginId(reporterLoginId)).willReturn(Optional.of(reporter));
+        given(reviewReportRepository.existsByReviewAndReporter(review, reporter)).willReturn(false);
+        given(reviewReportRepository.save(any(ReviewReport.class))).willReturn(reviewReport);
+        given(reviewReportRepository.countByReview(review)).willReturn(5L);
+
+        // when
+        reviewReportService.reportReview(reviewId, reporterLoginId, request);
+
+        // then
+        verify(reviewRepository, times(2)).save(review);
+        assertThat(review.getStatus()).isEqualTo(ReviewStatus.HIDDEN);
+    }
+
+    @Test
+    @DisplayName("신고된 리뷰 목록 조회 성공")
+    void getReportedReviews_Success() {
+        // given
+        int page = 0;
+        int size = 10;
+        Pageable pageable = PageRequest.of(page, size);
+
+        List<ReviewReport> reports = List.of(reviewReport);
+        Page<ReviewReport> reportPage = new PageImpl<>(reports, pageable, 1);
+
+        given(reviewReportRepository.findUnprocessedReports(pageable)).willReturn(reportPage);
+
+        // when
+        PaginatedResponse<ReportedReviewResponse> response = reviewReportService.getReportedReviews(page, size);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getContent()).hasSize(1);
+        assertThat(response.getPage()).isEqualTo(page);
+        assertThat(response.getSize()).isEqualTo(size);
+        assertThat(response.getTotalElements()).isEqualTo(1L);
+
+        ReportedReviewResponse reportedReview = response.getContent().get(0);
+        assertThat(reportedReview.getReviewId()).isEqualTo(1L);
+        assertThat(reportedReview.getTitle()).isEqualTo("Test Review");
+        assertThat(reportedReview.getTotalReportCount()).isEqualTo(1L);
+        assertThat(reportedReview.getReports()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("리뷰 숨김 처리 성공")
+    void hideReview_Success() {
+        // given
+        Long reviewId = 1L;
+        String adminLoginId = "admin";
+        List<ReviewReport> reports = List.of(reviewReport);
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+        given(reviewReportRepository.findByReview(review)).willReturn(reports);
+
+        // when
+        reviewReportService.hideReview(reviewId, adminLoginId);
+
+        // then
+        assertThat(review.getStatus()).isEqualTo(ReviewStatus.HIDDEN);
+        assertThat(reviewReport.isProcessed()).isTrue();
+        verify(reviewRepository).save(review);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리뷰 숨김 처리 시 예외 발생")
+    void hideReview_ReviewNotFound_ThrowsException() {
+        // given
+        Long reviewId = 999L;
+        String adminLoginId = "admin";
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewReportService.hideReview(reviewId, adminLoginId))
+                .isInstanceOf(ReviewNotFoundException.class)
+                .hasMessage("숨김 처리할 리뷰를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("리뷰 숨김 해제 성공")
+    void showReview_Success() {
+        // given
+        Long reviewId = 1L;
+        String adminLoginId = "admin";
+        ReflectionTestUtils.setField(review, "status", ReviewStatus.HIDDEN);
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+        // when
+        reviewReportService.showReview(reviewId, adminLoginId);
+
+        // then
+        assertThat(review.getStatus()).isEqualTo(ReviewStatus.ACTIVE);
+        verify(reviewRepository).save(review);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리뷰 숨김 해제 시 예외 발생")
+    void showReview_ReviewNotFound_ThrowsException() {
+        // given
+        Long reviewId = 999L;
+        String adminLoginId = "admin";
+
+        given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewReportService.showReview(reviewId, adminLoginId))
+                .isInstanceOf(ReviewNotFoundException.class)
+                .hasMessage("숨김 해제할 리뷰를 찾을 수 없습니다.");
+    }
+}

--- a/src/test/java/com/cMall/feedShop/review/application/service/ReviewReportServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/review/application/service/ReviewReportServiceTest.java
@@ -243,10 +243,13 @@ class ReviewReportServiceTest {
         int size = 10;
         Pageable pageable = PageRequest.of(page, size);
 
+        List<Long> reviewIds = List.of(1L);
+        Page<Long> reviewIdPage = new PageImpl<>(reviewIds, pageable, 1);
+        
         List<ReviewReport> reports = List.of(reviewReport);
-        Page<ReviewReport> reportPage = new PageImpl<>(reports, pageable, 1);
 
-        given(reviewReportRepository.findUnprocessedReports(pageable)).willReturn(reportPage);
+        given(reviewReportRepository.findDistinctReviewIdsWithUnprocessedReports(pageable)).willReturn(reviewIdPage);
+        given(reviewReportRepository.findUnprocessedReportsByReviewIds(reviewIds)).willReturn(reports);
 
         // when
         PaginatedResponse<ReportedReviewResponse> response = reviewReportService.getReportedReviews(page, size);

--- a/src/test/java/com/cMall/feedShop/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/review/application/service/ReviewServiceTest.java
@@ -82,10 +82,16 @@ class ReviewServiceTest {
     private ReviewDuplicationValidator duplicationValidator;
 
     @Mock
+    private com.cMall.feedShop.review.domain.service.ReviewPurchaseVerificationService purchaseVerificationService;
+
+    @Mock
     private ReviewImageService reviewImageService;
     
     @Mock
     private com.cMall.feedShop.review.domain.repository.ReviewImageRepository reviewImageRepository;
+
+    @Mock
+    private com.cMall.feedShop.user.application.service.UserLevelService userLevelService;
 
     @Mock
     private GcpStorageService gcpStorageService;
@@ -178,6 +184,8 @@ class ReviewServiceTest {
             given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
             given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
             given(reviewRepository.save(any(Review.class))).willReturn(testReview);
+            doNothing().when(purchaseVerificationService).validateUserPurchasedProduct(any(User.class), any(Long.class));
+            doNothing().when(userLevelService).recordActivity(anyLong(), any(), anyString(), any(), anyString());
 
             // when
             ReviewCreateResponse response = reviewService.createReview(createRequest, null);
@@ -338,6 +346,8 @@ class ReviewServiceTest {
             given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
             given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
             given(reviewRepository.save(any(Review.class))).willReturn(testReview);
+            doNothing().when(purchaseVerificationService).validateUserPurchasedProduct(any(User.class), any(Long.class));
+            doNothing().when(userLevelService).recordActivity(anyLong(), any(), anyString(), any(), anyString());
 
             // 중복 검증 통과하도록 설정 (예외 발생 안함)
             doNothing().when(duplicationValidator).validateNoDuplicateActiveReview(1L, 1L);
@@ -373,8 +383,15 @@ class ReviewServiceTest {
             given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
             given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
             given(reviewRepository.save(any(Review.class))).willReturn(testReview);
+            doNothing().when(purchaseVerificationService).validateUserPurchasedProduct(any(User.class), any(Long.class));
+            doNothing().when(userLevelService).recordActivity(anyLong(), any(), anyString(), any(), anyString());
             given(gcpStorageService.uploadFilesWithDetails(any(List.class), eq(UploadDirectory.REVIEWS)))
                     .willReturn(List.of(mockResult));
+            
+            // ReviewImage Mock 설정
+            com.cMall.feedShop.review.domain.ReviewImage mockReviewImage = mock(com.cMall.feedShop.review.domain.ReviewImage.class);
+            given(mockReviewImage.getReviewImageId()).willReturn(1L);
+            given(reviewImageRepository.save(any(com.cMall.feedShop.review.domain.ReviewImage.class))).willReturn(mockReviewImage);
 
             // when
             ReviewCreateResponse response = reviewService.createReview(createRequest, imageFiles);
@@ -397,6 +414,8 @@ class ReviewServiceTest {
             given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
             given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
             given(reviewRepository.save(any(Review.class))).willReturn(testReview);
+            doNothing().when(purchaseVerificationService).validateUserPurchasedProduct(any(User.class), any(Long.class));
+            doNothing().when(userLevelService).recordActivity(anyLong(), any(), anyString(), any(), anyString());
 
             // when
             ReviewCreateResponse response = reviewService.createReview(createRequest, null);
@@ -480,6 +499,8 @@ class ReviewServiceTest {
             given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
             given(productRepository.findById(1L)).willReturn(Optional.of(testProduct));
             given(reviewRepository.save(any(Review.class))).willReturn(testReview);
+            doNothing().when(purchaseVerificationService).validateUserPurchasedProduct(any(User.class), any(Long.class));
+            doNothing().when(userLevelService).recordActivity(anyLong(), any(), anyString(), any(), anyString());
 
             // when
             ReviewCreateResponse response = reviewService.createReview(createRequest, emptyImageList);
@@ -528,6 +549,8 @@ class ReviewServiceTest {
                 assertThat(savedReview.getContent()).isEqualTo(createRequest.getContent());
                 return testReview;
             });
+            doNothing().when(purchaseVerificationService).validateUserPurchasedProduct(any(User.class), any(Long.class));
+            doNothing().when(userLevelService).recordActivity(anyLong(), any(), anyString(), any(), anyString());
 
             // when
             reviewService.createReview(createRequest, null);

--- a/src/test/java/com/cMall/feedShop/review/application/service/ReviewServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/review/application/service/ReviewServiceTest.java
@@ -19,7 +19,6 @@ import com.cMall.feedShop.review.domain.repository.ReviewRepository;
 import com.cMall.feedShop.product.domain.model.Product;
 import com.cMall.feedShop.product.domain.model.Category;
 import com.cMall.feedShop.review.domain.service.ReviewDuplicationValidator;
-import com.cMall.feedShop.review.domain.service.ReviewPurchaseVerificationService;
 import com.cMall.feedShop.store.domain.model.Store;
 import com.cMall.feedShop.product.domain.enums.DiscountType;
 import com.cMall.feedShop.user.domain.enums.UserRole;
@@ -58,7 +57,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.lenient;
 
 @ActiveProfiles("test")
 @ExtendWith(MockitoExtension.class)
@@ -82,9 +80,6 @@ class ReviewServiceTest {
 
     @Mock
     private ReviewDuplicationValidator duplicationValidator;
-
-    @Mock
-    private ReviewPurchaseVerificationService purchaseVerificationService;
 
     @Mock
     private ReviewImageService reviewImageService;
@@ -166,9 +161,6 @@ class ReviewServiceTest {
                 .build();
 
         ReflectionTestUtils.setField(reviewService, "gcpStorageService", gcpStorageService);
-        
-        // 구매이력검증 기본 Mock 설정 (모든 테스트에서 검증 통과하도록)
-        lenient().doNothing().when(purchaseVerificationService).validateUserPurchasedProduct(any(User.class), any(Long.class));
     }
 
     @AfterEach
@@ -550,163 +542,5 @@ class ReviewServiceTest {
         given(authentication.isAuthenticated()).willReturn(true);
         given(authentication.getName()).willReturn("test@test.com");
         given(authentication.getPrincipal()).willReturn("test@test.com"); // String으로 설정하면 getName()이 호출됨
-    }
-
-    // ========== 필터링 메서드 테스트들 ==========
-
-    @Test
-    @DisplayName("필터링된 리뷰 목록을 조회할 수 있다 - 평점 필터")
-    void getProductReviewsWithFilters_RatingFilter() {
-        // given
-        List<Review> reviews = List.of(testReview);
-        Page<Review> reviewPage = new PageImpl<>(reviews, PageRequest.of(0, 20), 1);
-        
-        given(reviewRepository.findActiveReviewsByProductIdWithFilters(
-                eq(1L), eq(5), isNull(), isNull(), isNull(), any()))
-                .willReturn(reviewPage);
-        given(reviewRepository.findAverageRatingByProductId(1L)).willReturn(4.5);
-        given(reviewRepository.countActiveReviewsByProductId(1L)).willReturn(10L);
-        given(reviewImageService.getReviewImages(1L)).willReturn(List.of());
-
-        // when
-        ReviewListResponse response = reviewService.getProductReviewsWithFilters(
-                1L, 0, 20, "latest", 5, null, null, null);
-
-        // then
-        assertThat(response.getReviews()).hasSize(1);
-        assertThat(response.getAverageRating()).isEqualTo(4.5);
-        assertThat(response.getTotalReviews()).isEqualTo(10L);
-        verify(reviewRepository).findActiveReviewsByProductIdWithFilters(
-                eq(1L), eq(5), isNull(), isNull(), isNull(), any());
-    }
-
-    @Test
-    @DisplayName("필터링된 리뷰 목록을 조회할 수 있다 - 3Element 필터")
-    void getProductReviewsWithFilters_3ElementFilter() {
-        // given
-        List<Review> reviews = List.of(testReview);
-        Page<Review> reviewPage = new PageImpl<>(reviews, PageRequest.of(0, 20), 1);
-        
-        given(reviewRepository.findActiveReviewsByProductIdWithFilters(
-                eq(1L), isNull(), eq(SizeFit.NORMAL), eq(Cushion.SOFT), eq(Stability.STABLE), any()))
-                .willReturn(reviewPage);
-        given(reviewRepository.findAverageRatingByProductId(1L)).willReturn(4.5);
-        given(reviewRepository.countActiveReviewsByProductId(1L)).willReturn(10L);
-        given(reviewImageService.getReviewImages(1L)).willReturn(List.of());
-
-        // when
-        ReviewListResponse response = reviewService.getProductReviewsWithFilters(
-                1L, 0, 20, "latest", null, "NORMAL", "SOFT", "STABLE");
-
-        // then
-        assertThat(response.getReviews()).hasSize(1);
-        verify(reviewRepository).findActiveReviewsByProductIdWithFilters(
-                eq(1L), isNull(), eq(SizeFit.NORMAL), eq(Cushion.SOFT), eq(Stability.STABLE), any());
-    }
-
-    @Test
-    @DisplayName("필터링된 리뷰 목록을 조회할 수 있다 - 복합 필터")
-    void getProductReviewsWithFilters_CombinedFilters() {
-        // given
-        List<Review> reviews = List.of(testReview);
-        Page<Review> reviewPage = new PageImpl<>(reviews, PageRequest.of(0, 20), 1);
-        
-        given(reviewRepository.findActiveReviewsByProductIdWithFilters(
-                eq(1L), eq(5), eq(SizeFit.NORMAL), eq(Cushion.SOFT), isNull(), any()))
-                .willReturn(reviewPage);
-        given(reviewRepository.findAverageRatingByProductId(1L)).willReturn(4.5);
-        given(reviewRepository.countActiveReviewsByProductId(1L)).willReturn(10L);
-        given(reviewImageService.getReviewImages(1L)).willReturn(List.of());
-
-        // when
-        ReviewListResponse response = reviewService.getProductReviewsWithFilters(
-                1L, 0, 20, "latest", 5, "NORMAL", "SOFT", null);
-
-        // then
-        assertThat(response.getReviews()).hasSize(1);
-        verify(reviewRepository).findActiveReviewsByProductIdWithFilters(
-                eq(1L), eq(5), eq(SizeFit.NORMAL), eq(Cushion.SOFT), isNull(), any());
-    }
-
-    @Test
-    @DisplayName("필터링된 리뷰 목록을 조회할 수 있다 - 모든 필터가 null")
-    void getProductReviewsWithFilters_NoFilters() {
-        // given
-        List<Review> reviews = List.of(testReview);
-        Page<Review> reviewPage = new PageImpl<>(reviews, PageRequest.of(0, 20), 1);
-        
-        given(reviewRepository.findActiveReviewsByProductIdWithFilters(
-                eq(1L), isNull(), isNull(), isNull(), isNull(), any()))
-                .willReturn(reviewPage);
-        given(reviewRepository.findAverageRatingByProductId(1L)).willReturn(4.5);
-        given(reviewRepository.countActiveReviewsByProductId(1L)).willReturn(10L);
-        given(reviewImageService.getReviewImages(1L)).willReturn(List.of());
-
-        // when
-        ReviewListResponse response = reviewService.getProductReviewsWithFilters(
-                1L, 0, 20, "latest", null, null, null, null);
-
-        // then
-        assertThat(response.getReviews()).hasSize(1);
-        verify(reviewRepository).findActiveReviewsByProductIdWithFilters(
-                eq(1L), isNull(), isNull(), isNull(), isNull(), any());
-    }
-
-    @Test
-    @DisplayName("잘못된 enum 값으로 필터링 시 예외가 발생한다")
-    void getProductReviewsWithFilters_InvalidEnumValue() {
-        // when & then
-        assertThatThrownBy(() -> 
-                reviewService.getProductReviewsWithFilters(
-                        1L, 0, 20, "latest", null, "INVALID_SIZE", null, null))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining("잘못된 필터 값입니다");
-    }
-
-    @Test
-    @DisplayName("페이지 크기가 범위를 벗어나면 기본값으로 설정된다")
-    void getProductReviewsWithFilters_InvalidPageSize() {
-        // given
-        List<Review> reviews = List.of(testReview);
-        Page<Review> reviewPage = new PageImpl<>(reviews, PageRequest.of(0, 20), 1);
-        
-        given(reviewRepository.findActiveReviewsByProductIdWithFilters(
-                eq(1L), isNull(), isNull(), isNull(), isNull(), any()))
-                .willReturn(reviewPage);
-        given(reviewRepository.findAverageRatingByProductId(1L)).willReturn(4.5);
-        given(reviewRepository.countActiveReviewsByProductId(1L)).willReturn(10L);
-        given(reviewImageService.getReviewImages(1L)).willReturn(List.of());
-
-        // when - 잘못된 페이지 크기 (0, 200)
-        ReviewListResponse response1 = reviewService.getProductReviewsWithFilters(
-                1L, 0, 0, "latest", null, null, null, null);
-        ReviewListResponse response2 = reviewService.getProductReviewsWithFilters(
-                1L, 0, 200, "latest", null, null, null, null);
-
-        // then - 기본값 20으로 설정됨
-        assertThat(response1.getSize()).isEqualTo(20);
-        assertThat(response2.getSize()).isEqualTo(20);
-    }
-
-    @Test
-    @DisplayName("음수 페이지 번호는 0으로 설정된다")
-    void getProductReviewsWithFilters_NegativePageNumber() {
-        // given
-        List<Review> reviews = List.of(testReview);
-        Page<Review> reviewPage = new PageImpl<>(reviews, PageRequest.of(0, 20), 1);
-        
-        given(reviewRepository.findActiveReviewsByProductIdWithFilters(
-                eq(1L), isNull(), isNull(), isNull(), isNull(), any()))
-                .willReturn(reviewPage);
-        given(reviewRepository.findAverageRatingByProductId(1L)).willReturn(4.5);
-        given(reviewRepository.countActiveReviewsByProductId(1L)).willReturn(10L);
-        given(reviewImageService.getReviewImages(1L)).willReturn(List.of());
-
-        // when
-        ReviewListResponse response = reviewService.getProductReviewsWithFilters(
-                1L, -5, 20, "latest", null, null, null, null);
-
-        // then
-        assertThat(response.getNumber()).isEqualTo(0);
     }
 }

--- a/src/test/java/com/cMall/feedShop/review/domain/ReviewReportTest.java
+++ b/src/test/java/com/cMall/feedShop/review/domain/ReviewReportTest.java
@@ -1,0 +1,249 @@
+package com.cMall.feedShop.review.domain;
+
+import com.cMall.feedShop.product.domain.model.Category;
+import com.cMall.feedShop.product.domain.model.Product;
+import com.cMall.feedShop.review.domain.enums.ReportReason;
+import com.cMall.feedShop.store.domain.model.Store;
+import com.cMall.feedShop.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("ReviewReport 도메인 테스트")
+class ReviewReportTest {
+
+    private Review review;
+    private User reporter;
+    private User reviewer;
+    private Product product;
+
+    @BeforeEach
+    void setUp() {
+        Store store = Store.builder()
+                .storeName("Test Store")
+                .sellerId(1L)
+                .build();
+        ReflectionTestUtils.setField(store, "storeId", 1L);
+
+        Category category = new Category();
+        ReflectionTestUtils.setField(category, "categoryId", 1L);
+
+        product = Product.builder()
+                .name("Test Product")
+                .price(BigDecimal.valueOf(10000))
+                .store(store)
+                .category(category)
+                .build();
+        ReflectionTestUtils.setField(product, "productId", 1L);
+
+        reviewer = User.builder()
+                .loginId("reviewer")
+                .password("password")
+                .email("reviewer@test.com")
+                .role(com.cMall.feedShop.user.domain.enums.UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(reviewer, "id", 1L);
+
+        review = Review.builder()
+                .user(reviewer)
+                .product(product)
+                .title("Test Review")
+                .content("Test Content")
+                .rating(5)
+                .sizeFit(com.cMall.feedShop.review.domain.enums.SizeFit.NORMAL)
+                .cushion(com.cMall.feedShop.review.domain.enums.Cushion.SOFT)
+                .stability(com.cMall.feedShop.review.domain.enums.Stability.STABLE)
+                .build();
+        ReflectionTestUtils.setField(review, "reviewId", 1L);
+
+        reporter = User.builder()
+                .loginId("reporter")
+                .password("password")
+                .email("reporter@test.com")
+                .role(com.cMall.feedShop.user.domain.enums.UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(reporter, "id", 2L);
+    }
+
+    @Test
+    @DisplayName("리뷰 신고 생성 성공")
+    void createReviewReport_Success() {
+        // given
+        ReportReason reason = ReportReason.ABUSIVE_LANGUAGE;
+        String description = "욕설이 포함되어 있습니다.";
+
+        // when
+        ReviewReport reviewReport = ReviewReport.builder()
+                .review(review)
+                .reporter(reporter)
+                .reason(reason)
+                .description(description)
+                .build();
+
+        // then
+        assertThat(reviewReport.getReview()).isEqualTo(review);
+        assertThat(reviewReport.getReporter()).isEqualTo(reporter);
+        assertThat(reviewReport.getReason()).isEqualTo(reason);
+        assertThat(reviewReport.getDescription()).isEqualTo(description);
+        assertThat(reviewReport.isProcessed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("리뷰가 null일 때 예외 발생")
+    void createReviewReport_NullReview_ThrowsException() {
+        // given
+        ReportReason reason = ReportReason.ABUSIVE_LANGUAGE;
+        String description = "욕설이 포함되어 있습니다.";
+
+        // when & then
+        assertThatThrownBy(() -> ReviewReport.builder()
+                .review(null)
+                .reporter(reporter)
+                .reason(reason)
+                .description(description)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("신고할 리뷰는 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("신고자가 null일 때 예외 발생")
+    void createReviewReport_NullReporter_ThrowsException() {
+        // given
+        ReportReason reason = ReportReason.ABUSIVE_LANGUAGE;
+        String description = "욕설이 포함되어 있습니다.";
+
+        // when & then
+        assertThatThrownBy(() -> ReviewReport.builder()
+                .review(review)
+                .reporter(null)
+                .reason(reason)
+                .description(description)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("신고자 정보는 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("신고 사유가 null일 때 예외 발생")
+    void createReviewReport_NullReason_ThrowsException() {
+        // given
+        String description = "욕설이 포함되어 있습니다.";
+
+        // when & then
+        assertThatThrownBy(() -> ReviewReport.builder()
+                .review(review)
+                .reporter(reporter)
+                .reason(null)
+                .description(description)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("신고 사유는 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("자신이 작성한 리뷰 신고 시 예외 발생")
+    void createReviewReport_SelfReport_ThrowsException() {
+        // given
+        ReportReason reason = ReportReason.ABUSIVE_LANGUAGE;
+        String description = "욕설이 포함되어 있습니다.";
+        
+        Review selfReview = Review.builder()
+                .user(reporter)
+                .product(product)
+                .title("Self Review")
+                .content("Self Content")
+                .rating(5)
+                .sizeFit(com.cMall.feedShop.review.domain.enums.SizeFit.NORMAL)
+                .cushion(com.cMall.feedShop.review.domain.enums.Cushion.SOFT)
+                .stability(com.cMall.feedShop.review.domain.enums.Stability.STABLE)
+                .build();
+        ReflectionTestUtils.setField(selfReview, "reviewId", 2L);
+
+        // when & then
+        assertThatThrownBy(() -> ReviewReport.builder()
+                .review(selfReview)
+                .reporter(reporter)
+                .reason(reason)
+                .description(description)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자신이 작성한 리뷰는 신고할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("신고 처리 완료 표시")
+    void markAsProcessed_Success() {
+        // given
+        ReviewReport reviewReport = ReviewReport.builder()
+                .review(review)
+                .reporter(reporter)
+                .reason(ReportReason.ABUSIVE_LANGUAGE)
+                .description("욕설이 포함되어 있습니다.")
+                .build();
+
+        assertThat(reviewReport.isProcessed()).isFalse();
+
+        // when
+        reviewReport.markAsProcessed();
+
+        // then
+        assertThat(reviewReport.isProcessed()).isTrue();
+    }
+
+    @Test
+    @DisplayName("설명이 없어도 신고 생성 가능")
+    void createReviewReport_WithoutDescription_Success() {
+        // given
+        ReportReason reason = ReportReason.SPAM;
+
+        // when
+        ReviewReport reviewReport = ReviewReport.builder()
+                .review(review)
+                .reporter(reporter)
+                .reason(reason)
+                .description(null)
+                .build();
+
+        // then
+        assertThat(reviewReport.getReview()).isEqualTo(review);
+        assertThat(reviewReport.getReporter()).isEqualTo(reporter);
+        assertThat(reviewReport.getReason()).isEqualTo(reason);
+        assertThat(reviewReport.getDescription()).isNull();
+        assertThat(reviewReport.isProcessed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("다양한 신고 사유로 신고 생성 가능")
+    void createReviewReport_WithDifferentReasons_Success() {
+        // given
+        ReportReason[] reasons = {
+                ReportReason.ABUSIVE_LANGUAGE,
+                ReportReason.SPAM,
+                ReportReason.INAPPROPRIATE_CONTENT,
+                ReportReason.FALSE_INFORMATION,
+                ReportReason.ADVERTISING,
+                ReportReason.COPYRIGHT_VIOLATION,
+                ReportReason.OTHER
+        };
+
+        for (ReportReason reason : reasons) {
+            // when
+            ReviewReport reviewReport = ReviewReport.builder()
+                    .review(review)
+                    .reporter(reporter)
+                    .reason(reason)
+                    .description("신고 설명")
+                    .build();
+
+            // then
+            assertThat(reviewReport.getReason()).isEqualTo(reason);
+            assertThat(reviewReport.isProcessed()).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/cMall/feedShop/review/domain/enums/ReportReasonTest.java
+++ b/src/test/java/com/cMall/feedShop/review/domain/enums/ReportReasonTest.java
@@ -1,0 +1,60 @@
+package com.cMall.feedShop.review.domain.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("ReportReason 열거형 테스트")
+class ReportReasonTest {
+
+    @Test
+    @DisplayName("모든 신고 사유가 올바른 설명을 가지고 있는지 확인")
+    void reportReasons_HaveCorrectDescriptions() {
+        assertThat(ReportReason.ABUSIVE_LANGUAGE.getDescription()).isEqualTo("욕설 및 비방");
+        assertThat(ReportReason.SPAM.getDescription()).isEqualTo("스팸 및 도배");
+        assertThat(ReportReason.INAPPROPRIATE_CONTENT.getDescription()).isEqualTo("부적절한 내용");
+        assertThat(ReportReason.FALSE_INFORMATION.getDescription()).isEqualTo("허위 정보");
+        assertThat(ReportReason.ADVERTISING.getDescription()).isEqualTo("광고성 내용");
+        assertThat(ReportReason.COPYRIGHT_VIOLATION.getDescription()).isEqualTo("저작권 침해");
+        assertThat(ReportReason.OTHER.getDescription()).isEqualTo("기타");
+    }
+
+    @Test
+    @DisplayName("신고 사유 개수가 7개인지 확인")
+    void reportReasons_Count() {
+        ReportReason[] reasons = ReportReason.values();
+        assertThat(reasons).hasSize(7);
+    }
+
+    @Test
+    @DisplayName("신고 사유별 toString 메서드 동작 확인")
+    void reportReasons_ToString() {
+        assertThat(ReportReason.ABUSIVE_LANGUAGE.toString()).isEqualTo("ABUSIVE_LANGUAGE");
+        assertThat(ReportReason.SPAM.toString()).isEqualTo("SPAM");
+        assertThat(ReportReason.INAPPROPRIATE_CONTENT.toString()).isEqualTo("INAPPROPRIATE_CONTENT");
+        assertThat(ReportReason.FALSE_INFORMATION.toString()).isEqualTo("FALSE_INFORMATION");
+        assertThat(ReportReason.ADVERTISING.toString()).isEqualTo("ADVERTISING");
+        assertThat(ReportReason.COPYRIGHT_VIOLATION.toString()).isEqualTo("COPYRIGHT_VIOLATION");
+        assertThat(ReportReason.OTHER.toString()).isEqualTo("OTHER");
+    }
+
+    @Test
+    @DisplayName("valueOf 메서드로 정상적으로 변환되는지 확인")
+    void reportReasons_ValueOf() {
+        assertThat(ReportReason.valueOf("ABUSIVE_LANGUAGE")).isEqualTo(ReportReason.ABUSIVE_LANGUAGE);
+        assertThat(ReportReason.valueOf("SPAM")).isEqualTo(ReportReason.SPAM);
+        assertThat(ReportReason.valueOf("INAPPROPRIATE_CONTENT")).isEqualTo(ReportReason.INAPPROPRIATE_CONTENT);
+        assertThat(ReportReason.valueOf("FALSE_INFORMATION")).isEqualTo(ReportReason.FALSE_INFORMATION);
+        assertThat(ReportReason.valueOf("ADVERTISING")).isEqualTo(ReportReason.ADVERTISING);
+        assertThat(ReportReason.valueOf("COPYRIGHT_VIOLATION")).isEqualTo(ReportReason.COPYRIGHT_VIOLATION);
+        assertThat(ReportReason.valueOf("OTHER")).isEqualTo(ReportReason.OTHER);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 값으로 valueOf 호출 시 예외 발생")
+    void reportReasons_ValueOf_InvalidValue_ThrowsException() {
+        assertThatThrownBy(() -> ReportReason.valueOf("INVALID_REASON"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/cMall/feedShop/review/domain/exception/DuplicateReportExceptionTest.java
+++ b/src/test/java/com/cMall/feedShop/review/domain/exception/DuplicateReportExceptionTest.java
@@ -1,0 +1,46 @@
+package com.cMall.feedShop.review.domain.exception;
+
+import com.cMall.feedShop.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("DuplicateReportException 테스트")
+class DuplicateReportExceptionTest {
+
+    @Test
+    @DisplayName("기본 생성자로 예외 생성")
+    void createException_WithDefaultConstructor() {
+        // when
+        DuplicateReportException exception = new DuplicateReportException();
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_REPORT);
+        assertThat(exception.getMessage()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("사용자 정의 메시지로 예외 생성")
+    void createException_WithCustomMessage() {
+        // given
+        String customMessage = "이미 신고한 리뷰입니다.";
+
+        // when
+        DuplicateReportException exception = new DuplicateReportException(customMessage);
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.DUPLICATE_REPORT);
+        assertThat(exception.getMessage()).isEqualTo(customMessage);
+    }
+
+    @Test
+    @DisplayName("예외가 BusinessException을 상속하는지 확인")
+    void exception_ExtendsBusinessException() {
+        // when
+        DuplicateReportException exception = new DuplicateReportException();
+
+        // then
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportRepositoryImplTest.java
+++ b/src/test/java/com/cMall/feedShop/review/infrastructure/repository/ReviewReportRepositoryImplTest.java
@@ -1,0 +1,272 @@
+package com.cMall.feedShop.review.infrastructure.repository;
+
+import com.cMall.feedShop.product.domain.model.Category;
+import com.cMall.feedShop.product.domain.model.Product;
+import com.cMall.feedShop.review.domain.Review;
+import com.cMall.feedShop.review.domain.ReviewReport;
+import com.cMall.feedShop.review.domain.enums.ReportReason;
+import com.cMall.feedShop.store.domain.model.Store;
+import com.cMall.feedShop.user.domain.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReviewReportRepositoryImpl 테스트")
+class ReviewReportRepositoryImplTest {
+
+    @InjectMocks
+    private ReviewReportRepositoryImpl reviewReportRepository;
+
+    @Mock
+    private ReviewReportJpaRepository reviewReportJpaRepository;
+
+    private Review review;
+    private User reporter;
+    private User reviewer;
+    private Product product;
+    private ReviewReport reviewReport;
+
+    @BeforeEach
+    void setUp() {
+        Store store = Store.builder()
+                .storeName("Test Store")
+                .sellerId(1L)
+                .build();
+        ReflectionTestUtils.setField(store, "storeId", 1L);
+
+        Category category = new Category();
+        ReflectionTestUtils.setField(category, "categoryId", 1L);
+
+        product = Product.builder()
+                .name("Test Product")
+                .price(BigDecimal.valueOf(10000))
+                .store(store)
+                .category(category)
+                .build();
+        ReflectionTestUtils.setField(product, "productId", 1L);
+
+        reviewer = User.builder()
+                .loginId("reviewer")
+                .password("password")
+                .email("reviewer@test.com")
+                .role(com.cMall.feedShop.user.domain.enums.UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(reviewer, "id", 1L);
+
+        review = Review.builder()
+                .user(reviewer)
+                .product(product)
+                .title("Test Review")
+                .content("Test Content")
+                .rating(5)
+                .sizeFit(com.cMall.feedShop.review.domain.enums.SizeFit.NORMAL)
+                .cushion(com.cMall.feedShop.review.domain.enums.Cushion.SOFT)
+                .stability(com.cMall.feedShop.review.domain.enums.Stability.STABLE)
+                .build();
+        ReflectionTestUtils.setField(review, "reviewId", 1L);
+
+        reporter = User.builder()
+                .loginId("reporter")
+                .password("password")
+                .email("reporter@test.com")
+                .role(com.cMall.feedShop.user.domain.enums.UserRole.USER)
+                .build();
+        ReflectionTestUtils.setField(reporter, "id", 2L);
+
+        reviewReport = ReviewReport.builder()
+                .review(review)
+                .reporter(reporter)
+                .reason(ReportReason.ABUSIVE_LANGUAGE)
+                .description("욕설이 포함되어 있습니다.")
+                .build();
+        ReflectionTestUtils.setField(reviewReport, "reportId", 1L);
+        ReflectionTestUtils.setField(reviewReport, "createdAt", LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("리뷰 신고 저장 성공")
+    void save_Success() {
+        // given
+        given(reviewReportJpaRepository.save(reviewReport)).willReturn(reviewReport);
+
+        // when
+        ReviewReport savedReport = reviewReportRepository.save(reviewReport);
+
+        // then
+        assertThat(savedReport).isEqualTo(reviewReport);
+        verify(reviewReportJpaRepository).save(reviewReport);
+    }
+
+    @Test
+    @DisplayName("리뷰와 신고자로 신고 조회 성공")
+    void findByReviewAndReporter_Success() {
+        // given
+        given(reviewReportJpaRepository.findByReviewAndReporter(review, reporter))
+                .willReturn(Optional.of(reviewReport));
+
+        // when
+        Optional<ReviewReport> result = reviewReportRepository.findByReviewAndReporter(review, reporter);
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get()).isEqualTo(reviewReport);
+        verify(reviewReportJpaRepository).findByReviewAndReporter(review, reporter);
+    }
+
+    @Test
+    @DisplayName("리뷰와 신고자로 신고 조회 - 결과 없음")
+    void findByReviewAndReporter_NotFound() {
+        // given
+        given(reviewReportJpaRepository.findByReviewAndReporter(review, reporter))
+                .willReturn(Optional.empty());
+
+        // when
+        Optional<ReviewReport> result = reviewReportRepository.findByReviewAndReporter(review, reporter);
+
+        // then
+        assertThat(result).isNotPresent();
+        verify(reviewReportJpaRepository).findByReviewAndReporter(review, reporter);
+    }
+
+    @Test
+    @DisplayName("중복 신고 존재 여부 확인 - 존재함")
+    void existsByReviewAndReporter_Exists() {
+        // given
+        given(reviewReportJpaRepository.existsByReviewAndReporter(review, reporter))
+                .willReturn(true);
+
+        // when
+        boolean exists = reviewReportRepository.existsByReviewAndReporter(review, reporter);
+
+        // then
+        assertThat(exists).isTrue();
+        verify(reviewReportJpaRepository).existsByReviewAndReporter(review, reporter);
+    }
+
+    @Test
+    @DisplayName("중복 신고 존재 여부 확인 - 존재하지 않음")
+    void existsByReviewAndReporter_NotExists() {
+        // given
+        given(reviewReportJpaRepository.existsByReviewAndReporter(review, reporter))
+                .willReturn(false);
+
+        // when
+        boolean exists = reviewReportRepository.existsByReviewAndReporter(review, reporter);
+
+        // then
+        assertThat(exists).isFalse();
+        verify(reviewReportJpaRepository).existsByReviewAndReporter(review, reporter);
+    }
+
+    @Test
+    @DisplayName("리뷰별 신고 목록 조회 성공")
+    void findByReview_Success() {
+        // given
+        List<ReviewReport> reports = List.of(reviewReport);
+        given(reviewReportJpaRepository.findByReview(review)).willReturn(reports);
+
+        // when
+        List<ReviewReport> result = reviewReportRepository.findByReview(review);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0)).isEqualTo(reviewReport);
+        verify(reviewReportJpaRepository).findByReview(review);
+    }
+
+    @Test
+    @DisplayName("미처리된 신고 목록 조회 성공")
+    void findUnprocessedReports_Success() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+        List<ReviewReport> reports = List.of(reviewReport);
+        Page<ReviewReport> reportPage = new PageImpl<>(reports, pageable, 1);
+        
+        given(reviewReportJpaRepository.findByIsProcessedFalseOrderByCreatedAtDesc(pageable))
+                .willReturn(reportPage);
+
+        // when
+        Page<ReviewReport> result = reviewReportRepository.findUnprocessedReports(pageable);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0)).isEqualTo(reviewReport);
+        assertThat(result.getTotalElements()).isEqualTo(1L);
+        verify(reviewReportJpaRepository).findByIsProcessedFalseOrderByCreatedAtDesc(pageable);
+    }
+
+    @Test
+    @DisplayName("리뷰별 신고 개수 조회 성공")
+    void countByReview_Success() {
+        // given
+        long expectedCount = 3L;
+        given(reviewReportJpaRepository.countByReview(review)).willReturn(expectedCount);
+
+        // when
+        long count = reviewReportRepository.countByReview(review);
+
+        // then
+        assertThat(count).isEqualTo(expectedCount);
+        verify(reviewReportJpaRepository).countByReview(review);
+    }
+
+    @Test
+    @DisplayName("신고 삭제 성공")
+    void deleteById_Success() {
+        // given
+        Long reportId = 1L;
+
+        // when
+        reviewReportRepository.deleteById(reportId);
+
+        // then
+        verify(reviewReportJpaRepository).deleteById(reportId);
+    }
+
+    @Test
+    @DisplayName("빈 리스트 반환 시 처리")
+    void findByReview_EmptyList() {
+        // given
+        given(reviewReportJpaRepository.findByReview(review)).willReturn(List.of());
+
+        // when
+        List<ReviewReport> result = reviewReportRepository.findByReview(review);
+
+        // then
+        assertThat(result).isEmpty();
+        verify(reviewReportJpaRepository).findByReview(review);
+    }
+
+    @Test
+    @DisplayName("신고 개수가 0일 때 처리")
+    void countByReview_ZeroCount() {
+        // given
+        given(reviewReportJpaRepository.countByReview(review)).willReturn(0L);
+
+        // when
+        long count = reviewReportRepository.countByReview(review);
+
+        // then
+        assertThat(count).isEqualTo(0L);
+        verify(reviewReportJpaRepository).countByReview(review);
+    }
+}


### PR DESCRIPTION
# 🛍️ Pull Request
## 📋 Summary
리뷰 신고 기능 구현 및 전체 테스트 코드 작성


**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore

---

## 🎯 What & Why

### 무엇을 했나요?
  - 리뷰 신고 기능의 전체 아키텍처 구현 (Controller, Service, Domain, Repository)
  - 신고 사유별 분류 및 중복 신고 방지 기능
  - 신고 임계값 도달 시 자동 숨김 처리
  - 관리자용 신고 관리 기능 (숨김/숨김해제)
  - 전체 계층에 대한 포괄적인 단위 테스트 작성 (21개 테스트 케이스)

### 왜 필요했나요?

  - 부적절한 리뷰 콘텐츠에 대한 사용자 신고 시스템 필요
  - 커뮤니티 품질 관리를 위한 자동화된 콘텐츠 필터링 시스템 구축
  - 관리자의 효율적인 신고 처리를 위한 관리 도구 제공

---

## 🔧 How (구현 방법)

### 주요 변경사항
  - Domain Layer: ReviewReport 엔티티, ReportReason enum, DuplicateReportException 추가
  - Service Layer: ReviewReportService - 신고 처리, 자동 숨김, 관리자 기능
  - Repository Layer: ReviewReportRepository 인터페이스 및 JPA 구현체
  - Controller Layer: 사용자/관리자용 신고 API 엔드포인트
  - DTO Layer: 요청/응답 DTO 클래스들


### 기술적 접근

  - 중복 신고 방지: DB 유니크 제약조건 + 비즈니스 로직 검증
  - 자동 숨김 처리: 신고 개수 임계값 기반 자동 처리 (설정 가능)
  - 계층별 책임 분리: Domain 검증, Service 비즈니스 로직, Repository 데이터 접근
  - 페이징 처리: 관리자용 신고 목록 조회 시 페이징 지원
  - 트랜잭션 관리: @Transactional을 통한 데이터 일관성 보장

---

## 🧪 Testing

### 테스트 방법

./gradlew test --tests "*ReviewReport*"

### 확인 사항
- [x] 기능 정상 동작 확인 
- [x] 기존 기능 영향 없음 
- [x] 예외 케이스 테스트 완료 
    - 중복 신고 방지
    - 자기 리뷰 신고 방지
    - 존재하지 않는 리뷰/사용자 처리
    - 자동 숨김 임계값 테스트
---

## 📎 관련 이슈 / 문서
- 관련 이슈: #651 
- 지라 백로그: MYCE-281

---

## 💬 Additional Notes
  - 신고 임계값은 application.yml에서 review.report.auto-hide-threshold 설정으로 조정 가능 (기본값: 5)
  - 모든 신고는 로그에 기록되어 추후 분석 가능
  - 관리자 기능은 추후 권한 체크 로직 추가 예정
  - 기존 Review 엔티티에 reportCount, status 필드 추가됨

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료 (21개 테스트 모두 통과)
- [x] 불필요한 로그 제거
- [x] API 문서 작성 (Swagger 어노테이션 포함)
- [x] 데이터베이스 스키마 검토 완료