### PR TITLE
MYCE-288 feat: 사용자 API Swagger 문서화 및 프로필 기능 버그 수정

### DIFF
--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/EmailRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/EmailRequest.java
@@ -1,8 +1,11 @@
 package com.cMall.feedShop.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
+@Schema(description = "이메일 요청 DTO")
 public class EmailRequest {
+    @Schema(description = "이메일 주소", example = "user@example.com", required = true)
     private String email;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/PasswordResetConfirmRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/PasswordResetConfirmRequest.java
@@ -1,16 +1,17 @@
 package com.cMall.feedShop.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 
 @Data
+@Schema(description = "비밀번호 재설정 확인 요청 DTO")
 public class PasswordResetConfirmRequest {
+    @Schema(description = "비밀번호 재설정 토큰", example = "abc123-def456-ghi789", required = true)
     @NotBlank(message = "토큰은 필수입니다.")
     private String token;
 
+    @Schema(description = "새 비밀번호 (영문, 숫자, 특수문자 포함, 8자 이상)", example = "newpassword123!", required = true)
     @NotBlank(message = "새 비밀번호는 필수입니다.")
-    // 여기에 필요에 따라 비밀번호 유효성 검사 어노테이션을 추가할 수 있습니다.
-    // 예를 들어, @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
-    // @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^&+=]).{8,}$", message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
     private String newPassword;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/ProfileUpdateRequest.java
@@ -1,8 +1,9 @@
 package com.cMall.feedShop.user.application.dto.request;
 import com.cMall.feedShop.user.domain.enums.FootArchType;
 import com.cMall.feedShop.user.domain.enums.FootWidth;
-import com.cMall.feedShop.user.domain.enums.Gender; // Import the correct Gender enum
+import com.cMall.feedShop.user.domain.enums.Gender;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,29 +13,41 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @Builder
+@Schema(description = "프로필 수정 요청 DTO")
 public class ProfileUpdateRequest {
+    @Schema(description = "실명 (2-50자)", example = "홍길동")
     @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
     private String name;
 
+    @Schema(description = "닉네임 (2-50자)", example = "길동이")
     @Size(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하로 입력해주세요.")
     private String nickname;
 
+    @Schema(description = "전화번호 (20자 이하)", example = "010-1234-5678")
     @Size(max = 20, message = "전화번호는 20자 이하로 입력해주세요.")
     private String phone;
 
+    @Schema(description = "생년월일", example = "1990-01-01")
     private LocalDate birthDate;
 
+    @Schema(description = "키 (cm)", example = "175")
     private Integer height;
 
+    @Schema(description = "발 사이즈 (mm)", example = "260")
     private Integer footSize;
 
+    @Schema(description = "몸무게 (kg)", example = "70")
     private Integer weight;
 
+    @Schema(description = "발 너비", example = "NORMAL")
     private FootWidth footWidth;
 
+    @Schema(description = "발 아치 타입", example = "NORMAL")
     private FootArchType footArchType;
 
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
     private String profileImageUrl;
 
+    @Schema(description = "성별", example = "MALE")
     private Gender gender;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/UserLoginRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/UserLoginRequest.java
@@ -1,5 +1,6 @@
 package com.cMall.feedShop.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,11 +11,17 @@ import lombok.ToString;
 @ToString
 @Getter
 @Setter
+@Schema(description = "로그인 요청 DTO")
 public class UserLoginRequest {
+    @Schema(description = "이메일 주소", example = "user@example.com", required = true)
     @NotNull
     private String email;
+    
+    @Schema(description = "비밀번호", example = "password123!", required = true)
     @NotNull
     private String password;
+    
+    @Schema(description = "reCAPTCHA 토큰", example = "03AFcWeA...", required = true)
     @NotNull
     private String recaptchaToken;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/UserSignUpRequest.java
@@ -3,6 +3,7 @@ package com.cMall.feedShop.user.application.dto.request;
 import com.cMall.feedShop.annotation.CustomEncryption;
 import com.cMall.feedShop.annotation.CustomPasswordMatch;
 import com.cMall.feedShop.user.domain.enums.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Column;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -14,18 +15,23 @@ import lombok.Setter;
 @Getter
 @Setter
 @CustomPasswordMatch
+@Schema(description = "회원가입 요청 DTO")
 public class UserSignUpRequest {
+    @Schema(description = "실명 (2-50자)", example = "홍길동", required = true)
     @NotBlank(message = "이름은 필수 입력 값입니다.")
     @Size(min = 2, max = 50, message = "이름은 2자 이상 50자 이하로 입력해주세요.")
     private String name;
 
+    @Schema(description = "이메일 주소", example = "user@example.com", required = true)
     @NotBlank(message = "이메일은 필수 입력 값입니다.")
     @Email(message = "유효한 이메일 주소를 입력해주세요.")
     @Size(max = 255, message = "이메일은 255자 이하로 입력해주세요.")
     private String email;
 
+    @Schema(description = "로그인 ID (자동 생성됨)", example = "user123")
     private String loginId;
 
+    @Schema(description = "비밀번호 (영문, 숫자, 특수문자 포함, 8자 이상)", example = "password123!", required = true)
     @CustomEncryption
     @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     @Size(min = 8, max = 255, message = "비밀번호는 8자 이상으로 입력해주세요.")
@@ -33,13 +39,17 @@ public class UserSignUpRequest {
             message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
     private String password;
 
+    @Schema(description = "비밀번호 확인", example = "password123!", required = true)
     @NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")
-    private String confirmPassword; // 비밀번호 확인 필드
+    private String confirmPassword;
 
+    @Schema(description = "전화번호", example = "010-1234-5678", required = true)
     @NotBlank(message = "휴대폰 번호는 필수입니다.")
     private String phone;
 
+    @Schema(description = "닉네임", example = "길동이")
     private String nickname;
 
+    @Schema(description = "사용자 역할", example = "USER")
     private UserRole role = UserRole.USER;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/request/UserWithdrawRequest.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/request/UserWithdrawRequest.java
@@ -1,5 +1,6 @@
 package com.cMall.feedShop.user.application.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -12,11 +13,14 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "회원 탈퇴 요청 DTO")
 public class UserWithdrawRequest {
+    @Schema(description = "이메일 주소", example = "user@example.com", required = true)
     @NotBlank(message = "이메일은 필수 입력값입니다.")
     @Email(message = "유효한 이메일 형식이 아닙니다.")
     private String email;
 
+    @Schema(description = "비밀번호 (8-20자)", example = "password123", required = true)
     @NotBlank(message = "비밀번호는 필수 입력값입니다.")
     @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
     private String password;

--- a/src/main/java/com/cMall/feedShop/user/application/dto/response/UserLoginResponse.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/response/UserLoginResponse.java
@@ -1,6 +1,7 @@
 package com.cMall.feedShop.user.application.dto.response;
 
 import com.cMall.feedShop.user.domain.enums.UserRole;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,13 +9,26 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 @Builder
+@Schema(description = "로그인 응답 DTO")
 public class UserLoginResponse {
+    @Schema(description = "로그인 ID", example = "user123")
     private String loginId; // 사용자의 로그인 ID
+    
+    @Schema(description = "사용자 역할", example = "USER")
     private UserRole role;
+    
+    @Schema(description = "JWT 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String token;
+    
+    @Schema(description = "닉네임", example = "길동이")
     private String nickname;
 
+    @Schema(description = "MFA 2단계 인증 필요 여부", example = "false")
     private boolean requiresMfa; // MFA 2단계 인증 필요 여부
+    
+    @Schema(description = "MFA 인증을 위한 임시 토큰", example = "temp_token_123")
     private String tempToken; // MFA 인증을 위한 임시 토큰
+    
+    @Schema(description = "이메일 주소", example = "user@example.com")
     private String email;
 }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/response/UserProfileResponse.java
@@ -3,6 +3,7 @@ package com.cMall.feedShop.user.application.dto.response;
 import com.cMall.feedShop.user.domain.enums.Gender;
 import com.cMall.feedShop.user.domain.model.User;
 import com.cMall.feedShop.user.domain.model.UserProfile;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,24 +13,48 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @Builder
+@Schema(description = "사용자 프로필 응답 DTO")
 public class UserProfileResponse {
+    @Schema(description = "사용자 ID", example = "1")
     private Long userId;
-    private String username;
+    
+    @Schema(description = "로그인 ID", example = "user123")
+    private String loginId;
+    
+    @Schema(description = "이메일 주소", example = "user@example.com")
     private String email;
+    
+    @Schema(description = "실명", example = "홍길동")
     private String name;
+    
+    @Schema(description = "닉네임", example = "길동이")
     private String nickname;
+    
+    @Schema(description = "전화번호", example = "010-1234-5678")
     private String phone;
+    
+    @Schema(description = "성별", example = "MALE")
     private Gender gender;
+    
+    @Schema(description = "생년월일", example = "1990-01-01")
     private LocalDate birthDate;
+    
+    @Schema(description = "키 (cm)", example = "175")
     private Integer height;
+    
+    @Schema(description = "몸무게 (kg)", example = "70")
     private Integer weight;
+    
+    @Schema(description = "발 사이즈 (mm)", example = "260")
     private Integer footSize;
+    
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
     private String profileImageUrl;
 
     public static UserProfileResponse from(User user, UserProfile userProfile) {
         return UserProfileResponse.builder()
                 .userId(user.getId())
-                .username(user.getUsername())
+                .loginId(user.getLoginId())
                 .email(user.getEmail())
                 .name(userProfile != null ? userProfile.getName() : null)
                 .nickname(userProfile != null ? userProfile.getNickname() : null)
@@ -46,7 +71,7 @@ public class UserProfileResponse {
     public static UserProfileResponse from(User user) {
         return UserProfileResponse.builder()
                 .userId(user.getId())
-                .username(user.getUsername())
+                .loginId(user.getLoginId())
                 .email(user.getEmail())
                 .build();
     }

--- a/src/main/java/com/cMall/feedShop/user/application/dto/response/UserResponse.java
+++ b/src/main/java/com/cMall/feedShop/user/application/dto/response/UserResponse.java
@@ -3,6 +3,7 @@ package com.cMall.feedShop.user.application.dto.response;
 import com.cMall.feedShop.user.domain.enums.UserRole;
 import com.cMall.feedShop.user.domain.enums.UserStatus;
 import com.cMall.feedShop.user.domain.model.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,14 +11,30 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Schema(description = "사용자 응답 DTO")
 public class UserResponse {
+    @Schema(description = "사용자 ID", example = "1")
     private Long userId;
+    
+    @Schema(description = "사용자 이름", example = "홍길동")
     private String username;
+    
+    @Schema(description = "이메일 주소 (마스킹됨)", example = "u***@example.com")
     private String email;
+    
+    @Schema(description = "전화번호", example = "010-****-5678")
     private String phone;
-    private UserRole role; 
+    
+    @Schema(description = "사용자 역할", example = "USER")
+    private UserRole role;
+    
+    @Schema(description = "사용자 상태", example = "ACTIVE")
     private UserStatus status;
+    
+    @Schema(description = "계정 생성일", example = "2024-01-01T00:00:00")
     private LocalDateTime createdAt;
+    
+    @Schema(description = "응답 메시지", example = "계정을 성공적으로 찾았습니다.")
     private String message;
 
     public static UserResponse from(User user) {

--- a/src/main/java/com/cMall/feedShop/user/application/service/UserProfileService.java
+++ b/src/main/java/com/cMall/feedShop/user/application/service/UserProfileService.java
@@ -32,12 +32,10 @@ public class UserProfileService {
 
     @Transactional(readOnly = true)
     public UserProfileResponse getUserProfile(Long userId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdWithProfile(userId)
                 .orElseThrow(() -> new RuntimeException("User not found with ID: " + userId));
 
-        Optional<UserProfile> userProfileOptional = userProfileRepository.findByUser(user);
-
-        return UserProfileResponse.from(user, userProfileOptional.orElse(null));
+        return UserProfileResponse.from(user, user.getUserProfile());
     }
 
     @Transactional
@@ -62,6 +60,9 @@ public class UserProfileService {
                     .birthDate(request.getBirthDate())
                     .profileImageUrl(null)
                     .build();
+            
+            user.setUserProfile(userProfile);
+            userProfileRepository.save(userProfile);
         } else {
             userProfile.updateProfile(
                     request.getName(),
@@ -75,6 +76,8 @@ public class UserProfileService {
                     request.getGender(),
                     request.getBirthDate()
             );
+            
+            userProfileRepository.save(userProfile);
         }
 
     }

--- a/src/main/java/com/cMall/feedShop/user/domain/model/DailyPoints.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/model/DailyPoints.java
@@ -1,9 +1,14 @@
 package com.cMall.feedShop.user.domain.model;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 
+@Schema(description = "일별 활동 점수 DTO")
 public class DailyPoints {
+    @Schema(description = "날짜", example = "2024-01-01")
     private LocalDate date;
+    
+    @Schema(description = "해당 날짜의 총 활동 점수", example = "150")
     private Integer totalPoints;
 
     public DailyPoints(LocalDate date, Integer totalPoints) {

--- a/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/cMall/feedShop/user/domain/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.cMall.feedShop.user.domain.repository;
 
 import com.cMall.feedShop.user.domain.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByVerificationToken(String verificationToken);
 
     List<User> findByUserProfile_NameAndUserProfile_Phone(String name, String phone);
+    
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.userProfile WHERE u.id = :userId")
+    Optional<User> findByIdWithProfile(@Param("userId") Long userId);
 }

--- a/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
+++ b/src/main/java/com/cMall/feedShop/user/presentation/UserAuthController.java
@@ -6,7 +6,6 @@ import com.cMall.feedShop.common.dto.ApiResponse;
 import com.cMall.feedShop.user.application.dto.request.EmailRequest;
 import com.cMall.feedShop.user.application.dto.request.PasswordResetConfirmRequest;
 import com.cMall.feedShop.user.application.dto.request.UserLoginRequest;
-
 import com.cMall.feedShop.user.application.dto.request.UserSignUpRequest;
 import com.cMall.feedShop.user.application.dto.response.MfaStatusResponse;
 import com.cMall.feedShop.user.application.dto.response.UserLoginResponse;
@@ -15,6 +14,12 @@ import com.cMall.feedShop.common.captcha.GoogleRecaptchaVerificationService;
 import com.cMall.feedShop.user.application.service.MfaService;
 import com.cMall.feedShop.user.application.service.UserAuthService;
 import com.cMall.feedShop.user.application.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +28,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "인증", description = "회원가입, 로그인, 비밀번호 재설정 등 인증 관련 API")
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -33,100 +39,204 @@ public class UserAuthController {
     private final RecaptchaVerificationService recaptchaService;
     private final MfaService mfaService;
 
-
+    @Operation(
+            summary = "회원가입",
+            description = "새로운 사용자를 등록합니다. 이메일 인증이 필요하며, 인증 완료 후 로그인이 가능합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원가입 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (입력 값 오류, 이메일 형식 오류 등)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 존재하는 이메일"
+            )
+    })
     @PostMapping("/signup")
     @ApiResponseFormat(message = "회원가입이 성공적으로 완료되었습니다.")
-    public ApiResponse<UserResponse> signUp(@Valid @RequestBody UserSignUpRequest request) {
+    public ApiResponse<UserResponse> signUp(
+            @Parameter(description = "회원가입 요청 데이터", required = true)
+            @Valid @RequestBody UserSignUpRequest request) {
         return ApiResponse.success(userService.signUp(request));
     }
 
+    @Operation(
+            summary = "로그인",
+            description = "이메일과 비밀번호로 로그인합니다. MFA가 활성화된 경우 2단계 인증이 필요할 수 있습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "로그인 성공",
+                    content = @Content(schema = @Schema(implementation = UserLoginResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (reCAPTCHA 토큰 오류)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "로그인 실패 (이메일/비밀번호 불일치, 이메일 미인증)"
+            )
+    })
     @PostMapping("/login")
-    @ApiResponseFormat
-    public ApiResponse<UserLoginResponse> login(@Valid @RequestBody UserLoginRequest request) {
+    @ApiResponseFormat(message = "로그인이 성공적으로 완료되었습니다.")
+    public ApiResponse<UserLoginResponse> login(
+            @Parameter(description = "로그인 요청 데이터 (이메일, 비밀번호, reCAPTCHA 토큰)", required = true)
+            @Valid @RequestBody UserLoginRequest request) {
         recaptchaService.verifyRecaptcha(request.getRecaptchaToken(), "login_submit");
 
-        // 1단계 로그인 (이메일/비밀번호 검증)
         UserLoginResponse loginResponse = userAuthService.login(request);
-
-        // MFA 상태 확인
         MfaStatusResponse mfaStatus = mfaService.getMfaStatus(request.getEmail());
 
         if (mfaStatus != null && mfaStatus.isEnabled()) {
-            // MFA가 활성화된 경우 - 2단계 인증 필요
             UserLoginResponse mfaRequiredResponse = UserLoginResponse.builder()
                     .loginId(loginResponse.getLoginId())
                     .role(loginResponse.getRole())
                     .nickname(loginResponse.getNickname())
-                    .tempToken(loginResponse.getToken()) // 임시 토큰으로 사용
+                    .tempToken(loginResponse.getToken())
                     .email(request.getEmail())
                     .requiresMfa(true)
                     .build();
-
-            // ResponseEntity를 제거하고 ApiResponse 객체만 반환
             return ApiResponse.success(mfaRequiredResponse);
         } else {
-            // MFA가 비활성화된 경우 - 일반 로그인 완료
-            // ResponseEntity를 제거하고 ApiResponse 객체만 반환
             return ApiResponse.success(loginResponse);
         }
     }
 
+    @Operation(
+            summary = "이메일 인증",
+            description = "회원가입 시 발송된 이메일의 인증 링크를 통해 이메일을 인증합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "이메일 인증 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 인증 토큰"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "인증 토큰을 찾을 수 없음"
+            )
+    })
     @GetMapping("/verify-email")
-    @ApiResponseFormat(message = "이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다.") // AOP 적용
-    public ApiResponse<String> verifyEmail(@RequestParam("token") String token) {
+    @ApiResponseFormat(message = "이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다.")
+    public ApiResponse<String> verifyEmail(
+            @Parameter(description = "이메일 인증 토큰", required = true, example = "abc123-def456-ghi789")
+            @RequestParam("token") String token) {
         userService.verifyEmail(token);
-        // String을 반환하지만 AOP가 ApiResponse.success("이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다.", "이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다.")
-        // 형태로 래핑할 것입니다. 만약 데이터 부분에 메시지 문자열을 다시 넣고 싶지 않다면,
-        // ApiResponse.success(message)만 반환하도록 Aspect에서 로직을 조정해야 할 수도 있습니다.
-        // 현재 Aspect 로직은 `ApiResponse.success(message, result)` 형태이므로 result가 "이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다." 문자열이 됩니다.
-        // 만약 result가 String일 때 데이터를 null로 처리하고 싶다면 Aspect 로직을 수정해야 합니다.
         return ApiResponse.success("이메일 인증이 완료되었습니다. 이제 로그인할 수 있습니다.");
     }
 
+    @Operation(
+            summary = "계정 찾기",
+            description = "이름과 전화번호로 등록된 계정을 찾습니다. 이메일 주소가 마스킹되어 반환됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "계정 찾기 성공",
+                    content = @Content(schema = @Schema(implementation = UserResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "해당 정보로 등록된 계정을 찾을 수 없음"
+            )
+    })
     @GetMapping("/find-account")
-    @ApiResponseFormat(message = "계정 조회 처리 완료.")
-    public ResponseEntity<ApiResponse<List<UserResponse>>> findAccountByNameAndPhone(
+    @ApiResponseFormat(message = "계정을 성공적으로 찾았습니다.")
+    public ApiResponse<List<UserResponse>> findAccountByNameAndPhone(
+            @Parameter(description = "사용자 이름", required = true, example = "홍길동")
             @RequestParam("username") String username,
-            @RequestParam("phoneNumber") String phoneNumber
-    ) {
+            @Parameter(description = "전화번호", required = true, example = "010-1234-5678")
+            @RequestParam("phoneNumber") String phoneNumber) {
         List<UserResponse> accounts = userService.findByUsernameAndPhoneNumber(username, phoneNumber);
-
-        return new ResponseEntity<>(ApiResponse.success("계정을 성공적으로 찾았습니다.", accounts), HttpStatus.OK);
+        return ApiResponse.success(accounts);
     }
 
+    @Operation(
+            summary = "비밀번호 재설정 요청",
+            description = "이메일로 비밀번호 재설정 링크를 발송합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 재설정 이메일 발송 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "해당 이메일로 등록된 계정을 찾을 수 없음"
+            )
+    })
     @PostMapping("/forgot-password")
-    @ApiResponseFormat(message="비밀번호 재설정 링크가 이메일로 전송되었습니다.")
-    public ResponseEntity<ApiResponse<String>> findPassword(@RequestBody EmailRequest emailRequest) {
-        userAuthService.requestPasswordReset(emailRequest.getEmail());
-        return new ResponseEntity<>(ApiResponse.success("비밀번호 재설정 링크가 이메일로 전송되었습니다.", null), HttpStatus.OK);
+    @ApiResponseFormat(message = "비밀번호 재설정 이메일이 발송되었습니다.")
+    public ApiResponse<String> forgotPassword(
+            @Parameter(description = "비밀번호 재설정을 요청할 이메일", required = true)
+            @Valid @RequestBody EmailRequest request) {
+        userAuthService.requestPasswordReset(request.getEmail());
+        return ApiResponse.success("비밀번호 재설정 이메일이 발송되었습니다.");
     }
 
-    // 1. 비밀번호 재설정 링크 클릭 시 토큰을 처리하는 엔드포인트
-    // 이메일 링크를 통해 들어오는 GET 요청을 처리합니다.
-    // 주로 토큰의 유효성을 검사하고, 유효하면 프론트엔드의 비밀번호 재설정 폼으로 리다이렉트합니다.
-    @GetMapping("/reset-password")
-    @ApiResponseFormat(message = "비밀번호 재설정 페이지로 이동합니다.") // AOP 메시지
-    public ResponseEntity<ApiResponse<String>> showResetPasswordForm(@RequestParam("token") String token) {
-        // 토큰 유효성만 검사하고, 실제 비밀번호 변경은 POST 엔드포인트에서 진행합니다.
-        // userAuthService에 토큰 유효성 검사 메서드를 추가해야 합니다.
-        userAuthService.validatePasswordResetToken(token); // 토큰 유효성 검사 (만료, 존재 여부 등)
-
-        // 클라이언트를 프론트엔드의 비밀번호 재설정 폼 페이지로 리다이렉트하거나,
-        // 성공 메시지를 반환하여 클라이언트가 해당 폼으로 이동하도록 유도합니다.
-        // 여기서는 API 응답으로 처리하고, 프론트엔드가 이 응답을 받아 다음 단계를 진행한다고 가정합니다.
-        // 만약 직접 리다이렉트가 필요하다면 ResponseEntity.status(HttpStatus.FOUND).location(URI.create("...")).build(); 사용
-        return ResponseEntity.ok(ApiResponse.success("비밀번호 재설정 토큰이 유효합니다. 새 비밀번호를 입력해주세요.", token));
+    @Operation(
+            summary = "비밀번호 재설정 토큰 검증",
+            description = "비밀번호 재설정 이메일의 토큰이 유효한지 검증합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "토큰 검증 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 토큰"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "토큰을 찾을 수 없음"
+            )
+    })
+    @GetMapping("/reset-password/validate")
+    @ApiResponseFormat(message = "토큰이 유효합니다.")
+    public ApiResponse<String> validatePasswordResetToken(
+            @Parameter(description = "비밀번호 재설정 토큰", required = true, example = "abc123-def456-ghi789")
+            @RequestParam("token") String token) {
+        userAuthService.validatePasswordResetToken(token);
+        return ApiResponse.success("토큰이 유효합니다.");
     }
 
-    // 2. 새로운 비밀번호를 제출하여 실제로 비밀번호를 변경하는 엔드포인트
-    // 프론트엔드에서 새 비밀번호와 토큰을 받아 비밀번호를 업데이트합니다.
+    @Operation(
+            summary = "비밀번호 재설정",
+            description = "유효한 토큰과 새로운 비밀번호로 비밀번호를 재설정합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "비밀번호 재설정 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (토큰 오류, 비밀번호 형식 오류)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "토큰을 찾을 수 없음"
+            )
+    })
     @PostMapping("/reset-password")
     @ApiResponseFormat(message = "비밀번호가 성공적으로 재설정되었습니다.")
-    public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody @Valid PasswordResetConfirmRequest request) {
-        // userAuthService에 실제 비밀번호 재설정 로직을 호출합니다.
+    public ApiResponse<String> resetPassword(
+            @Parameter(description = "비밀번호 재설정 요청 데이터", required = true)
+            @Valid @RequestBody PasswordResetConfirmRequest request) {
         userAuthService.resetPassword(request.getToken(), request.getNewPassword());
-        return new ResponseEntity<>(ApiResponse.success("비밀번호가 성공적으로 재설정되었습니다.", null), HttpStatus.OK);
+        return ApiResponse.success("비밀번호가 성공적으로 재설정되었습니다.");
     }
-
-
 }

--- a/src/main/java/com/cMall/feedShop/user/presentation/UserController.java
+++ b/src/main/java/com/cMall/feedShop/user/presentation/UserController.java
@@ -1,5 +1,7 @@
 package com.cMall.feedShop.user.presentation;
 
+import com.cMall.feedShop.common.aop.ApiResponseFormat;
+import com.cMall.feedShop.common.dto.ApiResponse;
 import com.cMall.feedShop.user.application.dto.request.ProfileUpdateRequest;
 import com.cMall.feedShop.user.application.dto.request.UserWithdrawRequest;
 import com.cMall.feedShop.user.application.dto.response.UserProfileResponse;
@@ -7,6 +9,12 @@ import com.cMall.feedShop.user.application.service.UserProfileService;
 import com.cMall.feedShop.user.application.service.UserService;
 import com.cMall.feedShop.user.domain.model.DailyPoints;
 import com.cMall.feedShop.user.domain.model.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +29,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Tag(name = "사용자", description = "사용자 프로필 관리 및 회원 탈퇴 관련 API")
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
@@ -28,31 +37,66 @@ public class UserController {
     private final UserProfileService userProfileService;
     private final UserService userService;
 
+    @Operation(
+            summary = "내 프로필 조회",
+            description = "현재 로그인한 사용자의 프로필 정보를 조회합니다. 이름, 전화번호, 프로필 이미지 등의 정보를 포함합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserProfileResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요합니다"
+            )
+    })
     @GetMapping("/me/profile")
     @PreAuthorize("isAuthenticated()")
-    public UserProfileResponse getMyProfile(@AuthenticationPrincipal UserDetails userDetails) {
+    @ApiResponseFormat(message = "프로필 정보를 성공적으로 조회했습니다.")
+    public ApiResponse<UserProfileResponse> getMyProfile(
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
         if (userDetails == null) {
-            // 인증된 사용자가 아니면 적절한 예외를 던지거나 처리
             throw new AccessDeniedException("User not authenticated.");
         }
-        // userDetails가 User 클래스 인스턴스인지도 확인하는 것이 더 안전
         if (!(userDetails instanceof User)) {
             throw new IllegalStateException("Principal is not a User object.");
         }
         User currentUser = (User) userDetails;
-        return userProfileService.getUserProfile(currentUser.getId());
+        UserProfileResponse data = userProfileService.getUserProfile(currentUser.getId());
+        return ApiResponse.success(data);
     }
 
-    // 사용자 프로필을 조회하는 예시 메서드
+    @Operation(
+            summary = "특정 사용자 프로필 조회",
+            description = "특정 사용자의 프로필 정보를 조회합니다. 본인 또는 관리자만 조회 가능합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserProfileResponse.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "권한이 없습니다 (본인 또는 관리자만 조회 가능)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없습니다"
+            )
+    })
     @GetMapping("/{userId}/profile")
-    public UserProfileResponse getUserProfile(@PathVariable Long userId, @AuthenticationPrincipal UserDetails userDetails) {
-        // 현재 로그인한 사용자의 ID 가져오기
+    @ApiResponseFormat(message = "사용자 프로필 정보를 성공적으로 조회했습니다.")
+    public ApiResponse<UserProfileResponse> getUserProfile(
+            @Parameter(description = "조회할 사용자 ID", required = true, example = "1")
+            @PathVariable Long userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
         User currentUser = (User) userDetails;
         Long currentUserId = currentUser.getId();
 
-        // 요청된 userId와 현재 로그인한 사용자의 ID가 다른 경우 권한 확인
         if (!currentUserId.equals(userId)) {
-            // 관리자 권한이 있는지 확인 (예: ROLE_ADMIN)
             boolean isAdmin = currentUser.getAuthorities().stream()
                     .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
 
@@ -61,64 +105,172 @@ public class UserController {
             }
         }
 
-        // userProfileService를 사용하여 실제 비즈니스 로직 호출
-        UserProfileResponse response = userProfileService.getUserProfile(userId);
-        return response;
+        UserProfileResponse data = userProfileService.getUserProfile(userId);
+        return ApiResponse.success(data);
     }
 
-    // 사용자 프로필 정보 수정
+    @Operation(
+            summary = "내 프로필 정보 수정",
+            description = "현재 로그인한 사용자의 프로필 정보를 수정합니다. 이름, 전화번호 등의 정보를 변경할 수 있습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 수정 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (입력 값 오류)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요합니다"
+            )
+    })
     @PutMapping("/me/profile")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<Void> updateMyProfile(@AuthenticationPrincipal UserDetails userDetails, @RequestBody ProfileUpdateRequest request) {
+    @ApiResponseFormat(message = "프로필 정보가 성공적으로 수정되었습니다.")
+    public ApiResponse<Void> updateMyProfile(
+            @Parameter(description = "프로필 수정 요청 데이터", required = true)
+            @RequestBody ProfileUpdateRequest request,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
         User currentUser = (User) userDetails;
         userProfileService.updateUserProfile(currentUser.getId(), request);
-        return ResponseEntity.ok().build();
+        return ApiResponse.success(null);
     }
 
+    @Operation(
+            summary = "내 프로필 이미지 업로드",
+            description = "현재 로그인한 사용자의 프로필 이미지를 업로드합니다. 기존 이미지는 새로운 이미지로 교체됩니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "프로필 이미지 업로드 성공",
+                    content = @Content(schema = @Schema(implementation = String.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 이미지 파일"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요합니다"
+            )
+    })
     @PostMapping("/me/profile/image")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<String> updateMyProfileImage(@AuthenticationPrincipal UserDetails userDetails, @RequestParam("image") MultipartFile image) throws IOException {
+    @ApiResponseFormat(message = "프로필 이미지가 성공적으로 업로드되었습니다.")
+    public ApiResponse<String> updateMyProfileImage(
+            @Parameter(description = "업로드할 이미지 파일", required = true)
+            @RequestParam("image") MultipartFile image,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) throws IOException {
         User currentUser = (User) userDetails;
         String imageUrl = userProfileService.updateProfileImage(currentUser.getId(), image);
-        return ResponseEntity.ok(imageUrl);
+        return ApiResponse.success(imageUrl);
     }
 
-
-    // 관리자가 이메일로 사용자 탈퇴 처리
-    // (관리자 권한 필요)
+    @Operation(
+            summary = "관리자 회원 탈퇴 처리",
+            description = "관리자가 이메일을 통해 특정 사용자의 회원 탈퇴를 처리합니다. 관리자 권한이 필요합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 처리 완료"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "관리자 권한이 필요합니다"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없습니다"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 탈퇴 처리된 계정입니다"
+            )
+    })
     @DeleteMapping("/admin/by-email/{email}")
     @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<String> adminWithdrawUserByEmail(@PathVariable String email) {
-        userService.adminWithdrawUserByEmail(email); // 새로운 Service 메서드 호출
-        return ResponseEntity.ok("사용자 탈퇴 처리 완료 (관리자)");
+    @ApiResponseFormat(message = "사용자 탈퇴 처리가 완료되었습니다.")
+    public ApiResponse<String> adminWithdrawUserByEmail(
+            @Parameter(description = "탈퇴할 사용자의 이메일", required = true, example = "user@example.com")
+            @PathVariable String email) {
+        userService.adminWithdrawUserByEmail(email);
+        return ApiResponse.success("사용자 탈퇴 처리 완료 (관리자)");
     }
 
-    // 사용자가 자신의 계정을 이메일과 비밀번호로 탈퇴
+    @Operation(
+            summary = "회원 탈퇴",
+            description = "현재 로그인한 사용자가 본인 계정을 탈퇴합니다. 이메일과 비밀번호 확인이 필요합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "회원 탈퇴 완료"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (이메일 형식 오류, 비밀번호 길이 오류)"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요하거나 비밀번호가 일치하지 않습니다"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "403",
+                    description = "다른 사용자의 계정을 탈퇴할 수 없습니다"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "사용자를 찾을 수 없습니다"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "409",
+                    description = "이미 탈퇴 처리된 계정입니다"
+            )
+    })
     @DeleteMapping("/withdraw")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<String> withdrawUser(@RequestBody UserWithdrawRequest request) {
+    @ApiResponseFormat(message = "회원 탈퇴가 완료되었습니다.")
+    public ApiResponse<String> withdrawUser(
+            @Parameter(description = "회원 탈퇴 요청 데이터 (이메일, 비밀번호)", required = true)
+            @RequestBody UserWithdrawRequest request) {
         userService.withdrawCurrentUserWithPassword(request.getEmail(), request.getPassword());
-        return ResponseEntity.ok("회원 탈퇴 처리 완료");
+        return ApiResponse.success("회원 탈퇴 처리 완료");
     }
 
-    // 특정 사용자의 일별 활동 점수 통계 조회
+    @Operation(
+            summary = "일별 활동 점수 통계 조회",
+            description = "현재 로그인한 사용자의 일별 활동 점수 통계를 조회합니다. 기본적으로 최근 30일간의 데이터를 제공합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "일별 활동 점수 통계 조회 성공",
+                    content = @Content(schema = @Schema(implementation = DailyPoints.class))
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "로그인이 필요합니다"
+            )
+    })
     @GetMapping("/me/activity/daily-points")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<List<DailyPoints>> getDailyPoints(@AuthenticationPrincipal UserDetails userDetails,
-                                                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate) {
-
-        // 현재 로그인한 사용자 정보 가져오기
+    @ApiResponseFormat(message = "일별 활동 점수 통계를 성공적으로 조회했습니다.")
+    public ApiResponse<List<DailyPoints>> getDailyPoints(
+            @Parameter(description = "조회 시작 날짜 (ISO 형식: yyyy-MM-ddTHH:mm:ss)", required = false, example = "2024-01-01T00:00:00")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails) {
         User currentUser = (User) userDetails;
 
-        // startDate가 없으면 기본값 설정 (예: 30일 전)
         if (startDate == null) {
             startDate = LocalDateTime.now().minusDays(30);
         }
 
-        // 서비스 레이어의 비즈니스 로직 호출
-        List<DailyPoints> dailyStats = userService.getDailyPointsStatisticsForUser(currentUser, startDate);
-
-        // 결과를 HTTP 200 OK와 함께 반환
-        return ResponseEntity.ok(dailyStats);
+        List<DailyPoints> data = userService.getDailyPointsStatisticsForUser(currentUser, startDate);
+        return ApiResponse.success(data);
     }
 }

--- a/src/test/java/com/cMall/feedShop/user/application/service/UserProfileServiceTest.java
+++ b/src/test/java/com/cMall/feedShop/user/application/service/UserProfileServiceTest.java
@@ -89,8 +89,8 @@ class UserProfileServiceTest {
     void getUserProfile_Success_WithProfile() {
         // given
         Long userId = 1L;
-        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-        given(userProfileRepository.findByUser(testUser)).willReturn(Optional.of(testUserProfile));
+        testUser.setUserProfile(testUserProfile);
+        given(userRepository.findByIdWithProfile(userId)).willReturn(Optional.of(testUser));
 
         // when
         UserProfileResponse response = userProfileService.getUserProfile(userId);
@@ -98,7 +98,7 @@ class UserProfileServiceTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.getUserId()).isEqualTo(userId);
-        assertThat(response.getUsername()).isEqualTo("testuser");
+        assertThat(response.getLoginId()).isEqualTo("testuser");
         assertThat(response.getEmail()).isEqualTo("test@example.com");
         assertThat(response.getName()).isEqualTo("테스트유저");
         assertThat(response.getNickname()).isEqualTo("테스트닉네임");
@@ -110,8 +110,7 @@ class UserProfileServiceTest {
         assertThat(response.getFootSize()).isEqualTo(270);
         assertThat(response.getProfileImageUrl()).isEqualTo("https://example.com/profile.jpg");
 
-        verify(userRepository).findById(userId);
-        verify(userProfileRepository).findByUser(testUser);
+        verify(userRepository).findByIdWithProfile(userId);
     }
 
     @Test
@@ -119,8 +118,8 @@ class UserProfileServiceTest {
     void getUserProfile_Success_WithoutProfile() {
         // given
         Long userId = 1L;
-        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-        given(userProfileRepository.findByUser(testUser)).willReturn(Optional.empty());
+        testUser.setUserProfile(null);
+        given(userRepository.findByIdWithProfile(userId)).willReturn(Optional.of(testUser));
 
         // when
         UserProfileResponse response = userProfileService.getUserProfile(userId);
@@ -128,7 +127,7 @@ class UserProfileServiceTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.getUserId()).isEqualTo(userId);
-        assertThat(response.getUsername()).isEqualTo("testuser");
+        assertThat(response.getLoginId()).isEqualTo("testuser");
         assertThat(response.getEmail()).isEqualTo("test@example.com");
         assertThat(response.getName()).isNull();
         assertThat(response.getNickname()).isNull();
@@ -140,8 +139,7 @@ class UserProfileServiceTest {
         assertThat(response.getFootSize()).isNull();
         assertThat(response.getProfileImageUrl()).isNull();
 
-        verify(userRepository).findById(userId);
-        verify(userProfileRepository).findByUser(testUser);
+        verify(userRepository).findByIdWithProfile(userId);
     }
 
     @Test
@@ -149,15 +147,14 @@ class UserProfileServiceTest {
     void getUserProfile_Fail_UserNotFound() {
         // given
         Long userId = 999L;
-        given(userRepository.findById(userId)).willReturn(Optional.empty());
+        given(userRepository.findByIdWithProfile(userId)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> userProfileService.getUserProfile(userId))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("User not found with ID: " + userId);
 
-        verify(userRepository).findById(userId);
-        verify(userProfileRepository, never()).findByUser(any());
+        verify(userRepository).findByIdWithProfile(userId);
     }
 
     @Test


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
사용자 관련 API에 Swagger 문서화를 추가하고, 프로필 기능의 버그를 수정했습니다.


**Type**
- [x] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [x] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
UserController와 UserAuthController에 Swagger 문서화 추가
모든 사용자 관련 DTO에 @Schema 어노테이션 추가
UserProfileResponse의 필드명을 username에서 loginId로 변경하여 명확성 향상
UserProfileService의 프로필 저장 로직 수정
UserRepository에 findByIdWithProfile 메서드 추가로 N+1 문제 해결
테스트 코드 수정 및 최적화

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->
API 문서화 부족으로 프론트엔드 개발자와의 협업이 어려웠음
프로필 화면에서 이미지와 정보가 제대로 표시되지 않는 버그 발생
기존 프로필 조회 시 N+1 쿼리 문제로 성능 저하
필드명 혼동으로 인한 데이터 매핑 오류

---

## 🔧 How (구현 방법)
### 주요 변경사항
Swagger 문서화: @Tag, @Operation, @ApiResponses, @Parameter, @ApiResponseFormat 어노테이션 추가
DTO 개선: 모든 request/response DTO에 @Schema 어노테이션으로 필드 설명 추가
성능 최적화: LEFT JOIN FETCH를 사용한 fetch join으로 N+1 문제 해결
버그 수정: UserProfile 저장 로직 개선 및 필드명 명확화

### 기술적 접근
JPA Fetch Join: @Query("SELECT u FROM User u LEFT JOIN FETCH u.userProfile WHERE u.id = :userId")
Swagger 3.0: OpenAPI 3.0 스펙에 맞는 어노테이션 사용
AOP 활용: @ApiResponseFormat으로 일관된 응답 형식 보장
테스트 최적화: Mock 객체를 활용한 효율적인 단위 테스트


---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
단위 테스트: UserProfileServiceTest 수정 및 최적화
API 테스트: Swagger UI를 통한 엔드포인트 테스트
통합 테스트: 프로필 조회/수정/이미지 업로드 기능 검증

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #664
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-288](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->
Swagger 문서화된 API 목록
UserController:
GET /api/users/me/profile - 내 프로필 조회
GET /api/users/{userId}/profile - 특정 사용자 프로필 조회
PUT /api/users/me/profile - 내 프로필 수정
POST /api/users/me/profile/image - 프로필 이미지 업로드
DELETE /api/users/admin/by-email/{email} - 관리자 회원 탈퇴 (이메일)
POST /api/users/withdraw - 회원 탈퇴
GET /api/users/me/activity/daily-points - 일일 활동 포인트 조회
UserAuthController:
POST /api/auth/signup - 회원가입
POST /api/auth/login - 로그인
POST /api/auth/verify-email - 이메일 인증
POST /api/auth/find-account - 계정 찾기
POST /api/auth/forgot-password - 비밀번호 찾기
POST /api/auth/reset-password/validate - 비밀번호 재설정 토큰 검증
POST /api/auth/reset-password - 비밀번호 재설정
성능 개선 사항
Before: User 조회 후 UserProfile 별도 조회 (N+1 문제)
After: fetch join으로 한 번의 쿼리로 모든 데이터 조회

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
