### PR TITLE
MYCE-297 fix: 배포환경에서 상품 등록 시 GcpStorageService에서 오류 수정

### DIFF
--- a/src/main/java/com/cMall/feedShop/common/storage/GcpStorageService.java
+++ b/src/main/java/com/cMall/feedShop/common/storage/GcpStorageService.java
@@ -169,15 +169,15 @@ public class GcpStorageService implements StorageService {
 
     /**
      * 파일 경로에서 객체명 추출
-     * gs://feedshop-dev-bucket/images/reviews/filename.jpg -> images/reviews/filename.jpg
+     * {cdnBaseUrl}/images/reviews/filename.jpg -> images/reviews/filename.jpg
      */
     public String extractObjectName(String filePath) {
-        if (filePath == null || !filePath.startsWith("gs://")) {
+        if (filePath == null || !filePath.startsWith("https://")) {
             return null;
         }
 
-        String prefix = "gs://" + bucketName + "/";
-        if (filePath.startsWith(prefix)) {
+        if (filePath.startsWith(cdnBaseUrl)) {
+            String prefix = cdnBaseUrl + "/";
             return filePath.substring(prefix.length());
         }
         return null;
@@ -185,13 +185,13 @@ public class GcpStorageService implements StorageService {
 
     /**
      * 전체 파일 경로 생성
-     * gs://feedshop-dev-bucket/images/reviews/filename.jpg
+     * {cdnBaseUrl}/images/reviews/filename.jpg
      */
     public String getFullFilePath(String objectName) {
         if (objectName == null || objectName.isEmpty()) {
             return null;
         }
-        return String.format("gs://%s/%s", bucketName, objectName);
+        return cdnBaseUrl + "/" + objectName;
     }
 
     /**


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
운영배포에서 상품등록시 GcpStorageService 에서 오류나는 문제를 수정했습니다.

**Type**
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
기존에 cdn_base_url이 gs://~ 였던 부분에 맞춰서 작업되어 있던 부분을 최신에 맞춰서 수정했습니다.
최신 cdn_base_url : https://cdn.feedshop~

### 왜 필요했나요?
cdn_base_url이 이전 버전에 맞춰져 있어서 파싱할때 오류가 나고 있었습니다.

---

## 💬 Additional Notes
Feed 쪽도 이번 PR로 오류가 해결될 것으로 기대합니다.

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
