### PR TITLE
MYCE-302 : refactor/review - 리뷰 Sizefit 매치 오류 수정

### DIFF
--- a/src/main/java/com/cMall/feedShop/review/domain/enums/SizeFit.java
+++ b/src/main/java/com/cMall/feedShop/review/domain/enums/SizeFit.java
@@ -3,7 +3,7 @@ package com.cMall.feedShop.review.domain.enums;
 public enum SizeFit {
     VERY_SMALL(1, "매우 작음"),
     SMALL(2, "작음"),
-    NORMAL(3, "보통"),
+    NORMAL(3, "적당함"),
     BIG(4, "큼"),
     VERY_BIG(5, "매우 큼");
 

--- a/src/main/java/com/cMall/feedShop/review/presentation/ReviewUserController.java
+++ b/src/main/java/com/cMall/feedShop/review/presentation/ReviewUserController.java
@@ -141,7 +141,7 @@ public class ReviewUserController {
             @Parameter(description = "리뷰 제목", required = true) @Valid @NotBlank(message = "리뷰 제목은 필수입니다.") @RequestParam String title,
             @Parameter(description = "평점 (1-5점)", required = true) @Valid @NotNull(message = "평점은 필수입니다.") @Min(1) @Max(5) @RequestParam Integer rating,
             @Parameter(description = "리뷰 내용", required = true) @Valid @NotBlank(message = "리뷰 내용은 필수입니다.") @RequestParam String content,
-            @Parameter(description = "사이즈 착용감 (SMALL: 작음, NORMAL: 적당, LARGE: 큼)", required = true) @Valid @NotBlank(message = "사이즈 착용감은 필수입니다.") @RequestParam String sizeFit,
+            @Parameter(description = "사이즈 착용감 (VERY_SMALL: 매우 작음, SMALL: 작음, NORMAL: 적당함, BIG: 큼, VERY_BIG: 매우 큼)", required = true) @Valid @NotBlank(message = "사이즈 착용감은 필수입니다.") @RequestParam String sizeFit,
             @Parameter(description = "쿠션감 (HARD: 딱딱, MODERATE: 보통, SOFT: 부드러움, VERY_SOFT: 매우 부드러움)", required = true) @Valid @NotBlank(message = "쿠션감은 필수입니다.") @RequestParam String cushion,
             @Parameter(description = "안정성 (UNSTABLE: 불안정, MODERATE: 보통, STABLE: 안정적)", required = true) @Valid @NotBlank(message = "안정성은 필수입니다.") @RequestParam String stability,
             @Parameter(description = "리뷰 이미지 파일들 (선택사항, 최대 5개)") @RequestPart(value = "images", required = false) List<MultipartFile> images,

--- a/src/test/java/com/cMall/feedShop/review/domain/enums/SizeFitTest.java
+++ b/src/test/java/com/cMall/feedShop/review/domain/enums/SizeFitTest.java
@@ -14,7 +14,7 @@ class SizeFitTest {
         // when & then
         assertThat(SizeFit.VERY_SMALL.getDescription()).isEqualTo("매우 작음");
         assertThat(SizeFit.SMALL.getDescription()).isEqualTo("작음");
-        assertThat(SizeFit.NORMAL.getDescription()).isEqualTo("보통");
+        assertThat(SizeFit.NORMAL.getDescription()).isEqualTo("적당함");
         assertThat(SizeFit.BIG.getDescription()).isEqualTo("큼");
         assertThat(SizeFit.VERY_BIG.getDescription()).isEqualTo("매우 큼");
     }


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 리뷰 작성 시 사이즈 "적당함" 선택 오류 수정 -->


**Type**
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
  - SizeFit enum의 NORMAL 값 description을 "보통"에서 "적당함"으로 변경
  - 관련 API 문서(Swagger) 및 테스트 코드 업데이트
  - 프론트엔드와 백엔드 간 사이즈 옵션 텍스트 일치화

### 왜 필요했나요?
  - 운영 환경에서 리뷰 작성 시 사이즈 "적당함" 선택 시에만 500 Internal Server Error 발생
  - 프론트엔드에서 "적당함"으로 표시되는 옵션이 백엔드 enum에서는 "보통"으로 정의되어 매핑 불일치 발생
  - 다른 사이즈 옵션("매우 작음", "작음", "큼", "매우 큼")은 정상 동작하여 특정 값만의 문제로 확인

---

## 🔧 How (구현 방법)
### 주요 변경사항
  - SizeFit.java: NORMAL(3, "보통") → NORMAL(3, "적당함")
  - ReviewUserController.java: FormData API의 Swagger 문서에서 사이즈 옵션 설명 업데이트
  - SizeFitTest.java: enum description 검증 테스트 케이스 수정

### 기술적 접근
  - enum 값 자체(NORMAL)와 숫자 값(3)은 유지하여 기존 데이터와의 호환성 보장
  - description만 변경하여 프론트엔드 표시 텍스트와 일치
  - 테스트 코드 동시 수정으로 검증 로직 일관성 유지

---

## 🧪 Testing
### 테스트 방법
  1. 로컬 환경에서 단위 테스트 실행 (SizeFitTest)
  2. 운영 환경 배포 후 리뷰 작성 페이지에서 각 사이즈 옵션별 테스트
  3. "적당함" 선택 시 정상적으로 리뷰 작성 완료되는지 확인

### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료

---

## 📎 관련 이슈 / 문서
- 관련 이슈: #726 
- 지라 백로그: MYCE-302
---

## 💬 Additional Notes
  - 데이터 호환성: enum의 숫자 값(3)과 상수명(NORMAL)은 변경하지 않아 기존 DB 데이터와 완전 호환
  - 프론트엔드 영향 없음: 백엔드에서만 수정하여 프론트엔드 코드 변경 불필요
  - 즉시 배포 가능: 단순 텍스트 변경으로 사이드 이펙트 위험 최소화
  - 향후 개선 방안: 프론트엔드와 백엔드 간 enum 매핑 검증 로직 추가 고려

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
